### PR TITLE
Compact density default + 4-column masonry at 1600px

### DIFF
--- a/src/server/config/schema.ts
+++ b/src/server/config/schema.ts
@@ -36,7 +36,7 @@ export type DensityType = z.infer<typeof DensitySchema>;
 export const ThemeConfigSchema = z.object({
   default: ThemeSchema.default('system'),
   layout: LayoutSchema.default('masonry'),
-  density: DensitySchema.default('default'),
+  density: DensitySchema.default('compact'),
   customCss: z.string().optional(),
 });
 export type ThemeConfig = z.infer<typeof ThemeConfigSchema>;

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -798,6 +798,12 @@ header.top {
   column-gap: 20px;
 }
 
+@media (min-width: 1600px) {
+  .grid {
+    column-count: 4;
+  }
+}
+
 /* masonry: cards flow into columns; keep each card intact and spaced */
 .grid > .card {
   break-inside: avoid;

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -38,7 +38,7 @@
 
   let theme = $state(config.theme?.default ?? 'system');
   let layout = $state(config.theme?.layout ?? 'masonry');
-  let density = $state<'default' | 'compact'>('default');
+  let density = $state<'default' | 'compact'>('compact');
   let customCss = $state(config.theme?.customCss ?? '');
   let settingsOpen = $state(false);
   let saving = $state(false);
@@ -104,7 +104,7 @@
       if (storedDensity) {
         density = storedDensity as any;
       } else {
-        density = config.theme?.density ?? 'default';
+        density = config.theme?.density ?? 'compact';
       }
       document.documentElement.dataset.density = density;
     } catch {}


### PR DESCRIPTION
## Changes

- **Compact density is now the default.** `ThemeConfigSchema.density` defaults to `compact`; `Header.svelte` init + config fallback both default to `compact`. Existing installs without a saved density (and fresh installs) render compact; anyone who explicitly chose a density keeps it (localStorage / saved theme override still wins).
- **4-column masonry at ≥1600px.** Masonry `.grid` adds `@media (min-width: 1600px) { column-count: 4 }` (was 3 at all widths above 1080px, 1 below).

## Files
- `src/server/config/schema.ts` — density default `default` → `compact`
- `src/web/src/components/Header.svelte` — density state init + load fallback → `compact`
- `src/web/src/app.css` — 4-col masonry breakpoint

## Verified
Fresh in-memory DB: `data-density=compact`, masonry `column-count` = **4 @1680px**, **3 @1400px**. `bun run build` clean.