### PR TITLE
Polish: README logo/badges/Bun + discoverable torrent pause/play button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# Labby
+<p align="center">
+  <img src="src/web/public/icons/labby.svg" width="96" alt="Labby logo" />
+</p>
+
+<h1 align="center">Labby</h1>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/samuelloranger/labby" alt="License: MIT" /></a>
+  <a href="https://github.com/samuelloranger/labby/releases"><img src="https://img.shields.io/github/v/release/samuelloranger/labby" alt="Latest release" /></a>
+  <a href="https://github.com/samuelloranger/labby/actions/workflows/docker.yml"><img src="https://github.com/samuelloranger/labby/actions/workflows/docker.yml/badge.svg" alt="Docker build" /></a>
+  <a href="https://github.com/samuelloranger/labby/pkgs/container/labby"><img src="https://img.shields.io/badge/ghcr.io-labby-2496ED?logo=docker&logoColor=white" alt="Container image" /></a>
+</p>
 
 ![Dashboard Screenshot](docs/screenshot-v1.2.1.png)
 
@@ -19,6 +30,8 @@ A self-hosted homelab dashboard — lightweight like [Glance](https://github.com
 Do not expose Labby to the public internet without network-level access control.
 
 ## Quick start
+
+Requires [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`). Prefer no local toolchain? Use [Docker](#docker) instead — no Bun needed.
 
 ```bash
 bun install && (cd src/web && bun install)

--- a/src/server/integrations/qbittorrent.test.ts
+++ b/src/server/integrations/qbittorrent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { QbitConfig } from './qbittorrent';
-import { getQBittorrentTorrents } from './qbittorrent';
+import { getQBittorrentTorrents, qbittorrentAction } from './qbittorrent';
 
 describe('qBittorrent client', () => {
   test('reports missing config', async () => {
@@ -45,5 +45,36 @@ describe('qBittorrent client', () => {
       expect(result.torrents[0].name).toBe('test.iso');
       expect(result.torrents[0].progress).toBe(42);
     }
+  });
+
+  // qBittorrent 5.x reads `hashes` from the x-www-form-urlencoded body and
+  // rejects it as a query param with 400. Regression test: the action must
+  // send hashes in the body, never the URL.
+  test('pause sends hashes in the request body, not the query string', async () => {
+    const config: QbitConfig = { url: 'http://qb.test', user: 'admin', pass: 'admin' };
+    let captured: { url: string; body: string; contentType: string | null } | null = null;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/api/v2/auth/login')) {
+        return new Response('Ok.', { status: 200, headers: { 'set-cookie': 'SID=x; path=/' } });
+      }
+      captured = {
+        url,
+        body: init?.body ? String(init.body) : '',
+        contentType: new Headers(init?.headers).get('Content-Type'),
+      };
+      return new Response('', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await qbittorrentAction(config, 'HASH123', 'pause');
+    globalThis.fetch = originalFetch;
+
+    expect(result).toEqual({ ok: true });
+    expect(captured).not.toBeNull();
+    expect(captured?.url).not.toContain('hashes=');
+    expect(captured?.body).toContain('hashes=HASH123');
+    expect(captured?.contentType).toContain('application/x-www-form-urlencoded');
   });
 });

--- a/src/server/integrations/qbittorrent.ts
+++ b/src/server/integrations/qbittorrent.ts
@@ -102,13 +102,13 @@ export async function qbittorrentAction(
 
   try {
     for (const ep of endpoints) {
-      const res = await qbitFetch(
-        config,
-        `/api/v2/torrents/${ep}?hashes=${encodeURIComponent(hash)}`,
-        {
-          method: 'POST',
-        },
-      );
+      // qBittorrent reads `hashes` from the form body; sending it as a query
+      // param returns 400 on 5.x (and is ignored elsewhere).
+      const res = await qbitFetch(config, `/api/v2/torrents/${ep}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ hashes: hash }),
+      });
       if (res.ok) return { ok: true };
     }
     return { error: `qBittorrent ${action} failed` };

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -79,14 +79,17 @@
         <div class="tor" class:seed={seed}>
           <div class="top">
             <span class="dot {paused ? 'idle' : seed ? 'ok' : 'live'}"></span>
+            <span class="tname" title={t.name}>{t.name}</span>
+            <span class="pct">{Math.round(clampPercent(t.progress))}%</span>
             <button
-              class="tname"
-              style="background:none;border:none;cursor:pointer;text-align:left;padding:0"
+              class="tor-action"
               title={paused ? 'Resume' : 'Pause'}
+              aria-label={paused ? 'Resume torrent' : 'Pause torrent'}
               disabled={pending[t.hash]}
               onclick={() => toggle(t.hash, paused ? 'resume' : 'pause')}
-            >{t.name}</button>
-            <span class="pct">{Math.round(clampPercent(t.progress))}%</span>
+            >
+              <Icon icon={paused ? 'lucide:play' : 'lucide:pause'} size={15} />
+            </button>
           </div>
           <div class="bar"><i style:width="{clampPercent(t.progress)}%"></i></div>
           <div class="spd">
@@ -101,3 +104,30 @@
     </div>
   </Modal>
 {/if}
+
+<style>
+  .tor-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 30px;
+    height: 30px;
+    border: none;
+    border-radius: 8px;
+    background: var(--surface-2);
+    color: var(--ink-faint);
+    cursor: pointer;
+    transition:
+      background 0.15s var(--ease),
+      color 0.15s var(--ease);
+  }
+  .tor-action:hover:not(:disabled) {
+    background: var(--accent);
+    color: #fff;
+  }
+  .tor-action:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -39,7 +39,8 @@
   }
 
   function isPaused(s: string): boolean {
-    return s.includes('paused') || s === 'stopped';
+    // qBittorrent 5.x: stoppedUP / stoppedDL; older: pausedUP / pausedDL; transmission: stopped
+    return s.includes('paused') || s.includes('stopped');
   }
 </script>
 
@@ -76,7 +77,7 @@
       {#each list as t (t.hash)}
         {@const seed = isSeedingTorrent(t.state, t.progress)}
         {@const paused = isPaused(t.state)}
-        <div class="tor" class:seed={seed}>
+        <div class="tor" class:seed={seed} class:paused={paused}>
           <div class="top">
             <span class="dot {paused ? 'idle' : seed ? 'ok' : 'live'}"></span>
             <span class="tname" title={t.name}>{t.name}</span>
@@ -96,7 +97,7 @@
             <span class="dn">↓ {formatBytesPerSec(t.dlSpeed)}</span>
             <span>↑ {formatBytesPerSec(t.upSpeed)}</span>
             <span style="color:var(--ink-faint)">
-              {#if seed}seeding{#if t.ratio != null} · ratio {t.ratio.toFixed(1)}{/if}{:else}{formatEta(t.eta)}{/if}
+              {#if paused}paused{:else if seed}seeding{#if t.ratio != null} · ratio {t.ratio.toFixed(1)}{/if}{:else}{formatEta(t.eta)}{/if}
             </span>
           </div>
         </div>
@@ -129,5 +130,11 @@
   .tor-action:disabled {
     opacity: 0.5;
     cursor: default;
+  }
+  .tor.paused {
+    opacity: 0.55;
+  }
+  .tor.paused .bar i {
+    background: var(--ink-faint);
   }
 </style>


### PR DESCRIPTION
Two small commits.

**docs(readme):** add the flask logo + badges (license, release, Docker build, container image) and a Bun install note in Quick start, with a Docker escape hatch for users who don't want a local toolchain.

**fix(downloads):** the torrent pause/resume control was the torrent *name itself* — no visible affordance, two clicks deep in a modal. Replaced with a plain label + a dedicated play/pause icon button per row (matches the Docker widget's action buttons). Backend action was already wired; this just surfaces it. Web build passes.