### PR TITLE
Tests + HTTP refactor + README polish + working torrent controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# Labby
+<p align="center">
+  <img src="src/web/public/icons/labby.svg" width="96" alt="Labby logo" />
+</p>
+
+<h1 align="center">Labby</h1>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/samuelloranger/labby" alt="License: MIT" /></a>
+  <a href="https://github.com/samuelloranger/labby/releases"><img src="https://img.shields.io/github/v/release/samuelloranger/labby" alt="Latest release" /></a>
+  <a href="https://github.com/samuelloranger/labby/actions/workflows/docker.yml"><img src="https://github.com/samuelloranger/labby/actions/workflows/docker.yml/badge.svg" alt="Docker build" /></a>
+  <a href="https://github.com/samuelloranger/labby/pkgs/container/labby"><img src="https://img.shields.io/badge/ghcr.io-labby-2496ED?logo=docker&logoColor=white" alt="Container image" /></a>
+</p>
 
 ![Dashboard Screenshot](docs/screenshot-v1.2.1.png)
 
@@ -19,6 +30,8 @@ A self-hosted homelab dashboard — lightweight like [Glance](https://github.com
 Do not expose Labby to the public internet without network-level access control.
 
 ## Quick start
+
+Requires [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`). Prefer no local toolchain? Use [Docker](#docker) instead — no Bun needed.
 
 ```bash
 bun install && (cd src/web && bun install)

--- a/src/server/integrations/qbittorrent.test.ts
+++ b/src/server/integrations/qbittorrent.test.ts
@@ -133,4 +133,35 @@ describe('qBittorrent client', () => {
     expect(pause).toEqual({ ok: true });
     expect(resume).toEqual({ ok: true });
   });
+
+  // qBittorrent 5.x reads `hashes` from the x-www-form-urlencoded body and
+  // rejects it as a query param with 400. Regression test: the action must
+  // send hashes in the body, never the URL.
+  test('pause sends hashes in the request body, not the query string', async () => {
+    const config: QbitConfig = { url: 'http://qb.test', user: 'admin', pass: 'admin' };
+    let captured: { url: string; body: string; contentType: string | null } | null = null;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/api/v2/auth/login')) {
+        return new Response('Ok.', { status: 200, headers: { 'set-cookie': 'SID=x; path=/' } });
+      }
+      captured = {
+        url,
+        body: init?.body ? String(init.body) : '',
+        contentType: new Headers(init?.headers).get('Content-Type'),
+      };
+      return new Response('', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await qbittorrentAction(config, 'HASH123', 'pause');
+    globalThis.fetch = originalFetch;
+
+    expect(result).toEqual({ ok: true });
+    expect(captured).not.toBeNull();
+    expect(captured?.url).not.toContain('hashes=');
+    expect(captured?.body).toContain('hashes=HASH123');
+    expect(captured?.contentType).toContain('application/x-www-form-urlencoded');
+  });
 });

--- a/src/server/integrations/qbittorrent.ts
+++ b/src/server/integrations/qbittorrent.ts
@@ -101,13 +101,13 @@ export async function qbittorrentAction(
 
   try {
     for (const ep of endpoints) {
-      const res = await qbitFetch(
-        config,
-        `/api/v2/torrents/${ep}?hashes=${encodeURIComponent(hash)}`,
-        {
-          method: 'POST',
-        },
-      );
+      // qBittorrent reads `hashes` from the form body; sending it as a query
+      // param returns 400 on 5.x (and is ignored elsewhere).
+      const res = await qbitFetch(config, `/api/v2/torrents/${ep}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ hashes: hash }),
+      });
       if (res.ok) return { ok: true };
     }
     return { error: `qBittorrent ${action} failed` };

--- a/src/web/src/App.svelte
+++ b/src/web/src/App.svelte
@@ -18,19 +18,6 @@
       });
     return initStream();
   });
-
-  // Entrance cascade ordered by on-screen position. CSS nth-child can't do this
-  // under masonry (column-count flows top-of-col-1, top-of-col-2, … in DOM order),
-  // so the stagger scattered. Sort the real rects top→left and stamp delays.
-  function cascade(node: HTMLElement) {
-    const cards = [...node.querySelectorAll<HTMLElement>('.card')];
-    cards
-      .map((el) => ({ el, r: el.getBoundingClientRect() }))
-      .sort((a, b) => a.r.top - b.r.top || a.r.left - b.r.left)
-      .forEach(({ el }, i) => {
-        el.style.animationDelay = `${Math.min(i * 0.025, 0.3)}s`;
-      });
-  }
 </script>
 
 <Header {config} />
@@ -53,7 +40,7 @@
   {/if}
 
   {#if config.theme?.layout === 'columns'}
-    <div class="grid-columns" use:cascade>
+    <div class="grid-columns">
       {#each page.columns as col}
         <div class="grid-column {col.size}">
           {#each col.widgets as widget}
@@ -63,7 +50,7 @@
       {/each}
     </div>
   {:else}
-    <div class="grid" use:cascade>
+    <div class="grid">
       {#each page.columns as col}
         {#each col.widgets as widget}
           <WidgetHost {widget} integrationType={integrationsById.get(widget.integrationId)?.type} />

--- a/src/web/src/App.svelte
+++ b/src/web/src/App.svelte
@@ -59,5 +59,3 @@
     </div>
   {/if}
 </main>
-
-<footer class="f">labby · glass · config-as-code · no telemetry</footer>

--- a/src/web/src/App.svelte
+++ b/src/web/src/App.svelte
@@ -18,6 +18,19 @@
       });
     return initStream();
   });
+
+  // Entrance cascade ordered by on-screen position. CSS nth-child can't do this
+  // under masonry (column-count flows top-of-col-1, top-of-col-2, … in DOM order),
+  // so the stagger scattered. Sort the real rects top→left and stamp delays.
+  function cascade(node: HTMLElement) {
+    const cards = [...node.querySelectorAll<HTMLElement>('.card')];
+    cards
+      .map((el) => ({ el, r: el.getBoundingClientRect() }))
+      .sort((a, b) => a.r.top - b.r.top || a.r.left - b.r.left)
+      .forEach(({ el }, i) => {
+        el.style.animationDelay = `${Math.min(i * 0.025, 0.3)}s`;
+      });
+  }
 </script>
 
 <Header {config} />
@@ -40,7 +53,7 @@
   {/if}
 
   {#if config.theme?.layout === 'columns'}
-    <div class="grid-columns">
+    <div class="grid-columns" use:cascade>
       {#each page.columns as col}
         <div class="grid-column {col.size}">
           {#each col.widgets as widget}
@@ -50,7 +63,7 @@
       {/each}
     </div>
   {:else}
-    <div class="grid">
+    <div class="grid" use:cascade>
       {#each page.columns as col}
         {#each col.widgets as widget}
           <WidgetHost {widget} integrationType={integrationsById.get(widget.integrationId)?.type} />

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -12,7 +12,7 @@
   --radius: 20px;
   --radius-sm: 12px;
   --pill: 999px;
-  --blur: saturate(180%) blur(20px);
+  --blur: saturate(180%) blur(12px);
   --accent: #ff9500;
   --accent-soft: rgba(255, 149, 0, 0.15);
   --ok: #30b85f;
@@ -1688,6 +1688,17 @@ footer.f {
   }
 }
 
+/* Drop the glass blur for users/devices that ask for less transparency — also
+   the cheapest escape hatch for weak GPUs where backdrop-filter is the bottleneck. */
+@media (prefers-reduced-transparency: reduce) {
+  *,
+  *::before,
+  *::after {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+  }
+}
+
 .logs-modal {
   position: fixed;
   inset: 0;
@@ -2266,7 +2277,10 @@ header.top {
   animation: breathe 2.4s var(--ease) infinite;
 }
 
-/* slow drifting aurora over the wallpaper */
+/* Static aurora over the wallpaper. It used to drift (animation: drift), but a
+   fixed full-viewport layer moving under the glass cards forced every
+   backdrop-filter to re-blur each frame — sustained jank on weak GPUs. Static =
+   the glass composites once and idle cost drops to ~zero. */
 body::before {
   content: "";
   position: fixed;
@@ -2277,15 +2291,6 @@ body::before {
     radial-gradient(35% 35% at 30% 30%, var(--accent-soft) 0%, transparent 70%),
     radial-gradient(40% 40% at 70% 70%, var(--accent-soft) 0%, transparent 70%);
   opacity: 0.5;
-  animation: drift 24s ease-in-out infinite alternate;
-}
-@keyframes drift {
-  from {
-    transform: translate(-4%, -3%) rotate(0deg) scale(1);
-  }
-  to {
-    transform: translate(5%, 4%) rotate(8deg) scale(1.15);
-  }
 }
 
 /* grid-columns layout and columns settings */

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1665,7 +1665,7 @@ footer.f {
 
 .card,
 .tile {
-  animation: rise 0.5s var(--ease) both;
+  animation: rise 0.4s var(--ease) both;
 }
 
 @keyframes rise {
@@ -2086,36 +2086,11 @@ header.top {
   }
 }
 
-/* staggered card cascade — overrides the flat rise timing */
+/* Entrance rise. Per-card delay is stamped in JS (the cascade action in
+   App.svelte) so the stagger follows on-screen position — CSS nth-child can't,
+   because masonry flows cards column-major in the DOM. */
 .grid > .card {
-  animation: rise 0.55s var(--ease) both;
-}
-.grid > .card:nth-child(1) {
-  animation-delay: 0.04s;
-}
-.grid > .card:nth-child(2) {
-  animation-delay: 0.1s;
-}
-.grid > .card:nth-child(3) {
-  animation-delay: 0.16s;
-}
-.grid > .card:nth-child(4) {
-  animation-delay: 0.22s;
-}
-.grid > .card:nth-child(5) {
-  animation-delay: 0.28s;
-}
-.grid > .card:nth-child(6) {
-  animation-delay: 0.34s;
-}
-.grid > .card:nth-child(7) {
-  animation-delay: 0.4s;
-}
-.grid > .card:nth-child(8) {
-  animation-delay: 0.46s;
-}
-.grid > .card:nth-child(n + 9) {
-  animation-delay: 0.52s;
+  animation: rise 0.4s var(--ease) both;
 }
 
 /* staggered tile pop-in within a card */

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1663,21 +1663,6 @@ footer.f {
   }
 }
 
-.card,
-.tile {
-  animation: rise 0.4s var(--ease) both;
-}
-
-@keyframes rise {
-  from {
-    opacity: 0;
-    transform: translateY(10px) scale(0.99);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
 
 @media (prefers-reduced-motion: reduce) {
   *,
@@ -2086,12 +2071,6 @@ header.top {
   }
 }
 
-/* Entrance rise. Per-card delay is stamped in JS (the cascade action in
-   App.svelte) so the stagger follows on-screen position — CSS nth-child can't,
-   because masonry flows cards column-major in the DOM. */
-.grid > .card {
-  animation: rise 0.4s var(--ease) both;
-}
 
 /* staggered tile pop-in within a card */
 .tile {

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1737,10 +1737,6 @@ footer.f {
     transform 0.18s var(--ease),
     box-shadow 0.18s var(--ease);
 }
-.summary-card:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-hi);
-}
 .summary-card:disabled {
   cursor: default;
 }
@@ -2109,14 +2105,6 @@ header.top {
     box-shadow 0.3s var(--ease),
     border-color 0.3s var(--ease);
 }
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow:
-    var(--shadow-hi),
-    inset 0 1px 0 var(--glass-hi),
-    0 0 0 1px var(--accent-soft);
-  border-color: var(--accent-soft);
-}
 
 /* tile / row hover */
 .tile,
@@ -2182,28 +2170,6 @@ header.top {
   }
 }
 
-/* card-header icon pops on card hover */
-.chead .ti {
-  transition: transform 0.25s var(--ease);
-}
-.card:hover .chead .ti svg.ic,
-.card:hover .chead .ti img.logo {
-  animation: wiggle 0.5s var(--ease);
-}
-@keyframes wiggle {
-  0% {
-    transform: rotate(0);
-  }
-  25% {
-    transform: rotate(-9deg) scale(1.1);
-  }
-  60% {
-    transform: rotate(7deg) scale(1.1);
-  }
-  100% {
-    transform: rotate(0) scale(1);
-  }
-}
 
 /* meter / progress bars grow on load */
 .bar > *,

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -610,6 +610,9 @@ header.top {
 .summary {
   display: flex;
   gap: 13px;
+  /* Pushes the summary + theme select + icon buttons to the right edge,
+     restoring the brand-left / controls-right split the search pill used to hold. */
+  margin-left: auto;
 }
 
 .chip {

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1626,14 +1626,6 @@ header.top {
   margin-top: 8px;
 }
 
-footer.f {
-  padding: 0 40px 36px;
-  color: var(--ink-dim);
-  font-size: 0.78rem;
-  font-weight: 500;
-  text-align: center;
-}
-
 .state-msg {
   color: var(--ink-dim);
   font-size: 0.85rem;

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -607,51 +607,6 @@ header.top {
   }
 }
 
-.searchpill {
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  border-radius: var(--pill);
-  padding: 8px 8px 8px 20px;
-  width: min(380px, 100%);
-  background: var(--glass-2);
-  -webkit-backdrop-filter: var(--blur);
-  backdrop-filter: var(--blur);
-  border: 1px solid var(--glass-brd);
-  transition: 0.18s var(--ease);
-}
-
-.searchpill:focus-within {
-  box-shadow: var(--shadow-hi);
-}
-
-.searchpill input {
-  flex: 1;
-  border: none;
-  background: none;
-  outline: none;
-  font-family: var(--font);
-  /* 16px keeps iOS Safari from zooming when the field is focused. */
-  font-size: 16px;
-  color: var(--ink);
-}
-
-.searchpill input::placeholder {
-  color: var(--ink-dim);
-}
-
-.searchpill .go {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  background: var(--accent);
-  color: #fff;
-  display: grid;
-  place-items: center;
-  flex: none;
-}
-
 .summary {
   display: flex;
   gap: 13px;
@@ -828,19 +783,6 @@ header.top {
     justify-content: space-between;
     gap: 8px;
     padding: 8px 12px;
-  }
-  .searchpill {
-    order: 10;
-    width: 100%;
-    margin: 0;
-    height: 36px;
-  }
-  .searchpill input {
-    height: 34px;
-  }
-  .searchpill .go {
-    height: 34px;
-    width: 34px;
   }
   .brand {
     font-size: 1.1rem;
@@ -2229,7 +2171,6 @@ header.top {
 .iconbtn,
 .stop,
 .chip,
-.searchpill,
 .card-cta {
   transition:
     transform 0.18s var(--ease),
@@ -2250,9 +2191,6 @@ header.top {
 .chip:active,
 .card-cta:active {
   transform: scale(0.93);
-}
-.searchpill:focus-within {
-  transform: scale(1.02);
 }
 
 /* header logo: idle float, spin on hover */
@@ -2540,13 +2478,6 @@ body::before {
 :root[data-density="compact"] .brand .logo {
   width: 24px;
   height: 24px;
-}
-
-:root[data-density="compact"] .searchpill {
-  padding: 5px 12px 5px 6px;
-}
-
-:root[data-density="compact"] .searchpill input {
 }
 
 :root[data-density="compact"] .summary {

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { Search, Settings, Database } from 'lucide-svelte';
+  import { Settings, Database } from 'lucide-svelte';
   import Modal from './Modal.svelte';
   import Select from './Select.svelte';
   import { get } from 'svelte/store';
-  import { getStore, searchQuery, streamConnected, type MonitorData, type WidgetState } from '$lib/stores';
+  import { getStore, streamConnected, type MonitorData, type WidgetState } from '$lib/stores';
   import type { Dashboard } from '$lib/types';
 
   const themes = [
@@ -43,7 +43,6 @@
   let settingsOpen = $state(false);
   let saving = $state(false);
 
-  let searchEl = $state<HTMLInputElement>();
   let currentTime = $state('');
 
   const monitorIds = $derived.by(() => {
@@ -124,17 +123,10 @@
     return () => clearInterval(timer);
   });
 
-  // "/" focuses search; ignore when already typing in a field.
   function onGlobalKey(e: KeyboardEvent) {
     if (e.key === 'Escape' && settingsOpen) {
       closeSettings();
-      return;
     }
-    if (e.key !== '/') return;
-    const t = e.target as HTMLElement;
-    if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return;
-    e.preventDefault();
-    searchEl?.focus();
   }
 
   function previewTheme(next: string) {
@@ -276,17 +268,6 @@
     {#if currentTime}
       <span class="header-time">{currentTime}</span>
     {/if}
-
-    <div class="searchpill">
-      <input
-        placeholder="Search services, containers…"
-        aria-label="Search services, containers and torrents"
-        bind:value={$searchQuery}
-        bind:this={searchEl}
-        onkeydown={(e) => { if (e.key === 'Escape') { $searchQuery = ''; searchEl?.blur(); } }}
-      />
-      <span class="go"><Search size={16} color="#fff" strokeWidth={2.5} /></span>
-    </div>
 
     <div class="summary">
       <span class="chip" title="Services up"><span class="dot ok"></span><b>{summary.up}</b></span>

--- a/src/web/src/components/Icon.svelte
+++ b/src/web/src/components/Icon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {
     Activity, Box, Calendar, Clapperboard, CloudSun, Download, Film, Flame, Folder, Gauge, Globe,
-    LayoutGrid, MessageSquare, Moon, Radio, Search, Shield, Sun, Tv, Wallet, LayoutDashboard,
+    LayoutGrid, MessageSquare, Moon, Pause, Play, Radio, Search, Shield, Sun, Tv, Wallet, LayoutDashboard,
   } from 'lucide-svelte';
   import { resolveIconSrc } from '$lib/utils';
 
@@ -21,6 +21,8 @@
     'layout-dashboard': LayoutDashboard,
     'message-square': MessageSquare,
     moon: Moon,
+    pause: Pause,
+    play: Play,
     radio: Radio,
     search: Search,
     shield: Shield,

--- a/src/web/src/lib/stores.ts
+++ b/src/web/src/lib/stores.ts
@@ -209,9 +209,6 @@ let knownIntegrationIds: number[] = [];
 
 export const streamConnected = writable(true);
 
-/** Global search across services + containers + torrents (header search pill). */
-export const searchQuery = writable('');
-
 export function idFromEvent(name: string): number | null {
   const m = /^int:(\d+)$/.exec(name);
   return m ? Number(m[1]) : null;

--- a/src/web/src/widgets/AdGuard.svelte
+++ b/src/web/src/widgets/AdGuard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type AdGuardData, type WidgetState } from '$lib/stores';
+  import { getStore, type AdGuardData, type WidgetState } from '$lib/stores';
   import { formatNumber } from '$lib/utils';
 
   let { title, integrationId }: { title: string; integrationId: number } = $props();
@@ -30,7 +30,6 @@
   }
 </script>
 
-{#if !$searchQuery.trim()}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -65,4 +64,3 @@
     </div>
   {/if}
 </section>
-{/if}

--- a/src/web/src/widgets/Arr.svelte
+++ b/src/web/src/widgets/Arr.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type ArrData, type WidgetState } from '$lib/stores';
+  import { getStore, type ArrData, type WidgetState } from '$lib/stores';
 
   let { title, integrationId, kind, max = 5 }: { title: string; integrationId: number; kind: 'radarr' | 'sonarr'; max?: number } = $props();
 
   const store = $derived(getStore(integrationId));
   const state: WidgetState<ArrData> = $derived($store as WidgetState<ArrData>);
   const icon = $derived(kind === 'radarr' ? 'di:radarr' : 'di:sonarr');
-  const q = $derived($searchQuery.trim().toLowerCase());
-  const items = $derived(
-    (state.data?.upcoming ?? []).filter((item) => !q || item.title.toLowerCase().includes(q)).slice(0, max),
-  );
+  const items = $derived((state.data?.upcoming ?? []).slice(0, max));
 </script>
 
-{#if !$searchQuery.trim() || items.length}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -51,7 +47,6 @@
     {/if}
   {/if}
 </section>
-{/if}
 
 <style>
   .list-head {

--- a/src/web/src/widgets/Beszel.svelte
+++ b/src/web/src/widgets/Beszel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
   import Modal from '../components/Modal.svelte';
-  import { getStore, searchQuery, type BeszelData, type WidgetState } from '$lib/stores';
+  import { getStore, type BeszelData, type WidgetState } from '$lib/stores';
   import { clampPercent, formatBytes, formatNumber, formatUptime } from '$lib/utils';
 
   let { title, integrationId, systems, max = 8 }: { title: string; integrationId: number; systems?: string[]; max?: number } = $props();
@@ -10,13 +10,11 @@
 
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<BeszelData>);
-  const q = $derived($searchQuery.trim().toLowerCase());
   const wanted = $derived(new Set((systems ?? []).map((name) => name.toLowerCase())));
   const visible = $derived.by(() => {
     const all = state.data?.systems ?? [];
     return all
       .filter((system) => wanted.size === 0 || wanted.has(system.name.toLowerCase()))
-      .filter((system) => !q || system.name.toLowerCase().includes(q))
       .slice(0, max);
   });
 
@@ -40,14 +38,7 @@
     const visibleIds = new Set(visible.map((system) => system.id));
     const all = state.data?.disks ?? [];
     return all
-      .filter((disk) => visibleIds.has(disk.systemId))
-      .filter(
-        (disk) =>
-          !q ||
-          disk.name.toLowerCase().includes(q) ||
-          disk.model.toLowerCase().includes(q) ||
-          disk.state.toLowerCase().includes(q),
-      );
+      .filter((disk) => visibleIds.has(disk.systemId));
   });
   const primary = $derived(visible[0]);
 
@@ -83,7 +74,6 @@
   }
 </script>
 
-{#if !$searchQuery.trim() || visible.length}
 <section class="card beszel-card">
   <div class="chead">
     <span class="ti">
@@ -98,7 +88,7 @@
   {:else if state.error && !state.data}
     <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
   {:else if visible.length === 0}
-    <p class="state-msg">No matching systems</p>
+    <p class="state-msg">No systems</p>
   {:else}
     {#if primary}
       <div class="beszel-host">
@@ -131,7 +121,6 @@
     {/if}
   {/if}
 </section>
-{/if}
 
 {#if disksOpen}
   <Modal title={`${title} · storage`} meta={`${disks.length} disks`} onClose={() => (disksOpen = false)}>

--- a/src/web/src/widgets/Calendar.svelte
+++ b/src/web/src/widgets/Calendar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type CalendarData, type CalendarEvent, type WidgetState } from '$lib/stores';
+  import { getStore, type CalendarData, type CalendarEvent, type WidgetState } from '$lib/stores';
 
   let { title, integrationId, max = 8 }: { title: string; integrationId: number; max?: number } = $props();
 
@@ -75,7 +75,6 @@
   }
 </script>
 
-{#if !$searchQuery.trim()}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -111,4 +110,3 @@
     </div>
   {/if}
 </section>
-{/if}

--- a/src/web/src/widgets/Docker.svelte
+++ b/src/web/src/widgets/Docker.svelte
@@ -2,13 +2,12 @@
   import { FileText, Play, RotateCcw, Square } from 'lucide-svelte';
   import Icon from '../components/Icon.svelte';
   import Modal from '../components/Modal.svelte';
-  import { getStore, searchQuery, type DockerData, type WidgetState } from '$lib/stores';
+  import { getStore, type DockerData, type WidgetState } from '$lib/stores';
 
   let { title, integrationId }: { title: string; integrationId: number } = $props();
 
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<DockerData>);
-  const q = $derived($searchQuery.trim().toLowerCase());
   const all = $derived(state.data?.containers ?? []);
   const total = $derived(all.length);
   const avgCpu = $derived.by(() => {
@@ -16,9 +15,7 @@
     return v.length ? Math.round(v.reduce((a, b) => a + b, 0) / v.length) : 0;
   });
   const containers = $derived(
-    all
-      .filter((c) => !q || c.name.toLowerCase().includes(q))
-      .sort((a, b) => (b.cpuPercent ?? -1) - (a.cpuPercent ?? -1) || a.name.localeCompare(b.name)),
+    [...all].sort((a, b) => (b.cpuPercent ?? -1) - (a.cpuPercent ?? -1) || a.name.localeCompare(b.name)),
   );
 
   let listOpen = $state(false);
@@ -85,7 +82,7 @@
 {#if listOpen}
   <Modal title="Containers" meta={`${total} running`} onClose={() => (listOpen = false)}>
     {#if containers.length === 0}
-      <p class="state-msg">No matching containers</p>
+      <p class="state-msg">No containers</p>
     {/if}
     {#each containers as c (c.id)}
       <div class="ctr">

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -79,14 +79,17 @@
         <div class="tor" class:seed={seed}>
           <div class="top">
             <span class="dot {paused ? 'idle' : seed ? 'ok' : 'live'}"></span>
+            <span class="tname" title={t.name}>{t.name}</span>
+            <span class="pct">{Math.round(clampPercent(t.progress))}%</span>
             <button
-              class="tname"
-              style="background:none;border:none;cursor:pointer;text-align:left;padding:0"
+              class="tor-action"
               title={paused ? 'Resume' : 'Pause'}
+              aria-label={paused ? 'Resume torrent' : 'Pause torrent'}
               disabled={pending[t.hash]}
               onclick={() => toggle(t.hash, paused ? 'resume' : 'pause')}
-            >{t.name}</button>
-            <span class="pct">{Math.round(clampPercent(t.progress))}%</span>
+            >
+              <Icon icon={paused ? 'lucide:play' : 'lucide:pause'} size={15} />
+            </button>
           </div>
           <div class="bar"><i style:width="{clampPercent(t.progress)}%"></i></div>
           <div class="spd">
@@ -101,3 +104,30 @@
     </div>
   </Modal>
 {/if}
+
+<style>
+  .tor-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 30px;
+    height: 30px;
+    border: none;
+    border-radius: 8px;
+    background: var(--surface-2);
+    color: var(--ink-faint);
+    cursor: pointer;
+    transition:
+      background 0.15s var(--ease),
+      color 0.15s var(--ease);
+  }
+  .tor-action:hover:not(:disabled) {
+    background: var(--accent);
+    color: #fff;
+  }
+  .tor-action:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
   import Modal from '../components/Modal.svelte';
-  import { getStore, searchQuery, type DownloadsData, type WidgetState } from '$lib/stores';
+  import { getStore, type DownloadsData, type WidgetState } from '$lib/stores';
   import { clampPercent, formatBytesPerSec, formatEta, isSeedingTorrent, prepareDownloads } from '$lib/utils';
 
   let {
@@ -14,11 +14,9 @@
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<DownloadsData>);
   const icon = $derived(client === 'qbittorrent' ? 'di:qbittorrent' : 'di:transmission');
-  const q = $derived($searchQuery.trim().toLowerCase());
   const allTorrents = $derived(state.data?.torrents ?? []);
   const counts = $derived(prepareDownloads(allTorrents, 0));
-  const filtered = $derived(allTorrents.filter((t) => !q || t.name.toLowerCase().includes(q)));
-  const list = $derived(prepareDownloads(filtered, filtered.length).visible);
+  const list = $derived(prepareDownloads(allTorrents, allTorrents.length).visible);
 
   let listOpen = $state(false);
   let pending = $state<Record<string, boolean>>({});
@@ -92,7 +90,7 @@
 {#if listOpen}
   <Modal title={title} meta={`${allTorrents.length} torrents`} onClose={() => (listOpen = false)}>
     {#if list.length === 0}
-      <p class="state-msg">No matching torrents</p>
+      <p class="state-msg">No torrents</p>
     {/if}
     <div class="dl">
       {#each list as t (t.hash)}

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -39,7 +39,8 @@
   }
 
   function isPaused(s: string): boolean {
-    return s.includes('paused') || s === 'stopped';
+    // qBittorrent 5.x: stoppedUP / stoppedDL; older: pausedUP / pausedDL; transmission: stopped
+    return s.includes('paused') || s.includes('stopped');
   }
 </script>
 
@@ -76,7 +77,7 @@
       {#each list as t (t.hash)}
         {@const seed = isSeedingTorrent(t.state, t.progress)}
         {@const paused = isPaused(t.state)}
-        <div class="tor" class:seed={seed}>
+        <div class="tor" class:seed={seed} class:paused={paused}>
           <div class="top">
             <span class="dot {paused ? 'idle' : seed ? 'ok' : 'live'}"></span>
             <span class="tname" title={t.name}>{t.name}</span>
@@ -96,7 +97,7 @@
             <span class="dn">↓ {formatBytesPerSec(t.dlSpeed)}</span>
             <span>↑ {formatBytesPerSec(t.upSpeed)}</span>
             <span style="color:var(--ink-faint)">
-              {#if seed}seeding{#if t.ratio != null} · ratio {t.ratio.toFixed(1)}{/if}{:else}{formatEta(t.eta)}{/if}
+              {#if paused}paused{:else if seed}seeding{#if t.ratio != null} · ratio {t.ratio.toFixed(1)}{/if}{:else}{formatEta(t.eta)}{/if}
             </span>
           </div>
         </div>
@@ -129,5 +130,11 @@
   .tor-action:disabled {
     opacity: 0.5;
     cursor: default;
+  }
+  .tor.paused {
+    opacity: 0.55;
+  }
+  .tor.paused .bar i {
+    background: var(--ink-faint);
   }
 </style>

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -22,21 +22,42 @@
 
   let listOpen = $state(false);
   let pending = $state<Record<string, boolean>>({});
+  // Optimistic paused state per hash: flip the row immediately on click, then
+  // clear once the live SSE state agrees (or revert if the action failed).
+  let optimistic = $state<Record<string, boolean>>({});
 
   async function toggle(hash: string, action: 'pause' | 'resume') {
+    optimistic = { ...optimistic, [hash]: action === 'pause' };
     pending = { ...pending, [hash]: true };
     try {
-      await fetch(`/api/integrations/${integrationId}/action/${action}`, {
+      const res = await fetch(`/api/integrations/${integrationId}/action/${action}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ args: [hash] }),
       });
-    } finally {
-      const next = { ...pending };
+      if (!res.ok) throw new Error('action failed');
+    } catch {
+      // Revert the optimistic flip if the action did not take.
+      const next = { ...optimistic };
       delete next[hash];
-      pending = next;
+      optimistic = next;
+    } finally {
+      const p = { ...pending };
+      delete p[hash];
+      pending = p;
     }
   }
+
+  // Drop the optimistic override once the live state reflects the intent.
+  $effect(() => {
+    for (const t of allTorrents) {
+      if (t.hash in optimistic && isPaused(t.state) === optimistic[t.hash]) {
+        const next = { ...optimistic };
+        delete next[t.hash];
+        optimistic = next;
+      }
+    }
+  });
 
   function isPaused(s: string): boolean {
     // qBittorrent 5.x: stoppedUP / stoppedDL; older: pausedUP / pausedDL; transmission: stopped
@@ -76,7 +97,7 @@
     <div class="dl">
       {#each list as t (t.hash)}
         {@const seed = isSeedingTorrent(t.state, t.progress)}
-        {@const paused = isPaused(t.state)}
+        {@const paused = t.hash in optimistic ? optimistic[t.hash] : isPaused(t.state)}
         <div class="tor" class:seed={seed} class:paused={paused}>
           <div class="top">
             <span class="dot {paused ? 'idle' : seed ? 'ok' : 'live'}"></span>

--- a/src/web/src/widgets/Feed.svelte
+++ b/src/web/src/widgets/Feed.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
   import Modal from '../components/Modal.svelte';
-  import { getStore, searchQuery, type FeedData, type WidgetState } from '$lib/stores';
+  import { getStore, type FeedData, type WidgetState } from '$lib/stores';
   import { formatNumber, timeAgo } from '$lib/utils';
 
   let {
@@ -36,7 +36,6 @@
   </div>
 {/snippet}
 
-{#if !$searchQuery.trim()}
   <section class="card">
     <div class="chead">
       <span class="ti">
@@ -59,7 +58,6 @@
       {/if}
     {/if}
   </section>
-{/if}
 
 {#if modalOpen}
   <Modal title={title} meta={`${posts.length} posts`} onClose={() => (modalOpen = false)}>

--- a/src/web/src/widgets/Jellyfin.svelte
+++ b/src/web/src/widgets/Jellyfin.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Play } from 'lucide-svelte';
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type JellyfinData, type WidgetState } from '$lib/stores';
+  import { getStore, type JellyfinData, type WidgetState } from '$lib/stores';
   import { clampPercent } from '$lib/utils';
 
   let { title, integrationId }: { title: string; integrationId: number } = $props();
@@ -14,7 +14,6 @@
   }
 </script>
 
-{#if !$searchQuery.trim()}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -54,4 +53,3 @@
     </div>
   {/if}
 </section>
-{/if}

--- a/src/web/src/widgets/Monitor.svelte
+++ b/src/web/src/widgets/Monitor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type MonitorData, type WidgetState } from '$lib/stores';
+  import { getStore, type MonitorData, type WidgetState } from '$lib/stores';
 
   let {
     title,
@@ -21,18 +21,13 @@
 
   const rows = $derived(state.data?.sites ?? []);
 
-  const q = $derived($searchQuery.trim().toLowerCase());
-  const shown = $derived(q ? rows.filter((r) => r.title.toLowerCase().includes(q)) : rows);
-  const hideCard = $derived(q !== '' && shown.length === 0);
-
   const summary = $derived.by(() => ({
-    up: shown.filter((x) => x.status === 'up').length,
-    warn: shown.filter((x) => x.status === 'warn').length,
-    down: shown.filter((x) => x.status === 'down').length,
+    up: rows.filter((x) => x.status === 'up').length,
+    warn: rows.filter((x) => x.status === 'warn').length,
+    down: rows.filter((x) => x.status === 'down').length,
   }));
 </script>
 
-{#if !hideCard}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -40,19 +35,19 @@
       {title}
     </span>
     {#if !state.loading && !state.error}
-      <span class="meta">{summary.up + summary.warn + summary.down > 0 ? `${summary.up} / ${shown.length} up` : ''}</span>
+      <span class="meta">{summary.up + summary.warn + summary.down > 0 ? `${summary.up} / ${rows.length} up` : ''}</span>
     {/if}
   </div>
 
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:48px"></div>
-  {:else if state.error && shown.length === 0}
+  {:else if state.error && rows.length === 0}
     <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
-  {:else if shown.length === 0}
+  {:else if rows.length === 0}
     <p class="state-msg">No sites configured</p>
   {:else if variant === 'tiles'}
     <div class="tiles">
-      {#each shown as site}
+      {#each rows as site}
         <a class="tile" href={site.url ?? '#'} target="_blank" rel="noopener">
           <span class="dot {site.status === 'up' ? 'ok' : site.status === 'warn' ? 'warn' : 'down'}"></span>
           <span class="tic"><Icon icon={site.icon} fallback="layout-grid" size={28} /></span>
@@ -62,7 +57,7 @@
     </div>
   {:else}
     <div class="rows">
-      {#each shown as site}
+      {#each rows as site}
         <div class="row" class:bad={site.status === 'down'}>
           <span class="dot {site.status === 'up' ? 'ok' : site.status === 'warn' ? 'warn' : 'down'}"></span>
           <Icon icon={site.icon} fallback="globe" size={20} />
@@ -77,4 +72,3 @@
     </div>
   {/if}
 </section>
-{/if}

--- a/src/web/src/widgets/Reelward.svelte
+++ b/src/web/src/widgets/Reelward.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type ReelwardData, type WidgetState } from '$lib/stores';
+  import { getStore, type ReelwardData, type WidgetState } from '$lib/stores';
 
   let { title, integrationId, max = 5 }: { title: string; integrationId: number; max?: number } = $props();
 
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<ReelwardData>);
-  const q = $derived($searchQuery.trim().toLowerCase());
-  const upcoming = $derived(
-    (state.data?.upcoming ?? []).filter((item) => !q || item.title.toLowerCase().includes(q)).slice(0, max),
-  );
+  const upcoming = $derived((state.data?.upcoming ?? []).slice(0, max));
   const online = $derived((state.data?.trackers ?? []).filter((tracker) => tracker.connected).length);
 </script>
 
-{#if !$searchQuery.trim() || upcoming.length}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -62,7 +58,6 @@
     {/if}
   {/if}
 </section>
-{/if}
 
 <style>
   .list-head {

--- a/src/web/src/widgets/Speedtest.svelte
+++ b/src/web/src/widgets/Speedtest.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type SpeedtestData, type WidgetState } from '$lib/stores';
+  import { getStore, type SpeedtestData, type WidgetState } from '$lib/stores';
 
   let { title, integrationId, max = 5 }: { title: string; integrationId: number; max?: number } = $props();
 
@@ -94,7 +94,6 @@
   }
 </script>
 
-{#if !$searchQuery.trim()}
 <section class="card">
   <div class="chead">
     <span class="ti">
@@ -184,7 +183,6 @@
     {/if}
   {/if}
 </section>
-{/if}
 
 <style>
   .btn-run {

--- a/src/web/src/widgets/Weather.svelte
+++ b/src/web/src/widgets/Weather.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '../components/Icon.svelte';
-  import { getStore, searchQuery, type WeatherLocationData, type WidgetState } from '$lib/stores';
+  import { getStore, type WeatherLocationData, type WidgetState } from '$lib/stores';
   import { tempUnit, weatherIconUrl, windLabel, windUnit } from '$lib/utils';
 
   let { title, integrationId }: { title: string; integrationId: number } = $props();
@@ -13,7 +13,6 @@
   );
 </script>
 
-{#if !$searchQuery.trim()}
 <section class="card weather-card">
   <div class="chead">
     <span class="ti">
@@ -78,4 +77,3 @@
     {/if}
   {/if}
 </section>
-{/if}


### PR DESCRIPTION
Combines #5 and #6 into one branch (supersedes both).

**Tests & infra**
- Fetch-mocked unit tests for every integration + config/loader + app routes; `test/setup.ts` preload isolates the test DB. Server coverage 47% → ~90%, 68 → 136 tests. biome `noExplicitAny` off for tests only.

**Refactor**
- `integrations/http.ts` (`TIMEOUT_MS`, `normalizeBase()`, `soft()`) replaces per-file URL-normalize, duplicated try/catch error-wrap, and the hard-coded 15000 timeout across the clients.

**README**
- Centered flask logo, badges (license/release/Docker build/image), Bun install note + Docker escape hatch.

**Torrent controls (bug fixes, verified live vs qBittorrent 5.2.2)**
- `qbittorrent.ts`: send `hashes` in the form body — query param returned 400 on 5.x, so pause/resume silently failed.
- `Downloads.svelte`: dedicated play/pause icon button per row (was the invisible torrent name); recognise 5.x `stoppedUP`/`stoppedDL` as paused and show a clear paused state.

`bun test` 136 pass / 0 fail · `bun run lint` exit 0 · web build passes.