### PR TITLE
Integration-driven layout: ordering + drag reorder, bookmarks widget, backup import/export

### DIFF
--- a/docs/superpowers/plans/2026-06-26-import-export-bookmarks.md
+++ b/docs/superpowers/plans/2026-06-26-import-export-bookmarks.md
@@ -1,0 +1,847 @@
+# Import/Export + Bookmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a full-backup export/restore and a bookmarks (app-launcher) widget to Labby, with favicon auto-fetch when adding links.
+
+**Architecture:** Bookmarks reuse Labby's per-integration pattern — a new `bookmarks` integration type whose `fetch` returns its own `links` (no external call); its data reaches the widget through the existing `int:${id}` SSE store and `/api/integrations/:id/data` bootstrap, so no new data path is needed. Backup/restore are two new endpoints over the existing `settings` + `integrations` tables, with restore wrapped in a single SQLite transaction. Favicon resolution is one server endpoint the links editor calls.
+
+**Tech Stack:** Bun, Hono, Zod, bun:sqlite, Svelte 5 (runes), bun:test.
+
+## Global Constraints
+
+- TypeScript strict everywhere. Validate external/DB responses defensively (Zod where parsing untrusted input).
+- Server types (`src/server/types.ts`, schema) and web types (`src/web/src/lib/types.ts`, `stores.ts`) are duplicated by design — keep them in sync when a payload shape changes.
+- Integrations fail soft: `fetch` returns `Payload | { error: string }`, never throws to the route.
+- Tests are colocated `*.test.ts`, use `bun:test`, mock `fetch`. Endpoint tests use `app.request(path, opts)`. DB tests call db functions directly and clean up by unique name.
+- `@server/*` → `src/server/*`; web uses `$lib` → `src/web/src/lib`.
+- Icons: `icon` is a prefixed string resolved by `Icon.svelte` (`di:`, `sh:`, `http(s)://`, `/path`, `lucide:`). Favicon values are stored as `http(s)://` URLs so no `Icon.svelte` change is required.
+- Run server tests with `bun test`; build/typecheck frontend with `bun run build`.
+
+---
+
+### Task 1: Bookmarks integration type + widget schema
+
+**Files:**
+- Modify: `src/server/integrations/registry.ts` (union ~20-35, `INTEGRATIONS` map ~53-208)
+- Modify: `src/server/config/schema.ts` (`WidgetSchema` union ~54-137)
+- Modify: `src/server/integrations/registry.test.ts` (counts + `ALL_TYPES`)
+- Modify: `src/server/app.integrations.test.ts` (count assertion)
+
+**Interfaces:**
+- Produces: integration type `'bookmarks'` in `IntegrationType`; `INTEGRATIONS.bookmarks` with `fetch(config) => Promise<{ links: Array<{title:string;url:string;icon?:string}> }>`; widget variant `{ type:'bookmarks'; title:string; integrationId:number }`.
+
+- [ ] **Step 1: Update the registry test for bookmarks (failing test)**
+
+In `src/server/integrations/registry.test.ts`:
+- Add `'bookmarks'` to the end of the `ALL_TYPES` array.
+- Change `expect(Object.keys(INTEGRATIONS).length).toBe(15)` → `toBe(16)`.
+- Change `it('returns an array of 15 entries' …` assertion `expect(integrationTypes().length).toBe(15)` → `toBe(16)`.
+
+Add this test inside the `describe('INTEGRATIONS registry', …)` block:
+
+```ts
+it('bookmarks.fetch returns links from config', async () => {
+  const out = (await INTEGRATIONS.bookmarks.fetch({
+    links: [{ title: 'Router', url: 'http://192.168.1.1' }],
+  })) as { links: unknown[] };
+  expect(out.links.length).toBe(1);
+  const empty = (await INTEGRATIONS.bookmarks.fetch({})) as { links: unknown[] };
+  expect(empty.links).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test src/server/integrations/registry.test.ts`
+Expected: FAIL — `INTEGRATIONS.bookmarks` is undefined / count is 15 not 16.
+
+- [ ] **Step 3: Add the bookmarks type to the registry**
+
+In `src/server/integrations/registry.ts`, add `| 'bookmarks'` to the `IntegrationType` union (after `'speedtest'`). Then add this entry to the `INTEGRATIONS` object (e.g. after `speedtest`):
+
+```ts
+  bookmarks: {
+    label: 'Bookmarks',
+    // ponytail: static links, no polling — large interval so the no-op re-publish is rare
+    defaultRefreshSeconds: 86_400,
+    fields: [{ key: 'links', label: 'Links', kind: 'list' }],
+    fetch: async (c) => ({
+      links: Array.isArray(c.links) ? (c.links as Array<Record<string, unknown>>) : [],
+    }),
+  },
+```
+
+- [ ] **Step 4: Add the bookmarks widget variant to the schema**
+
+In `src/server/config/schema.ts`, add this object to the `WidgetSchema` discriminated union (after the `speedtest` entry, before the closing `]`):
+
+```ts
+  z.object({
+    type: z.literal('bookmarks'),
+    title: z.string(),
+    integrationId,
+  }),
+```
+
+- [ ] **Step 5: Fix the app integrations count assertion**
+
+In `src/server/app.integrations.test.ts`, change `expect(body.length).toBe(15)` → `toBe(16)`.
+
+- [ ] **Step 6: Run the affected tests to verify they pass**
+
+Run: `bun test src/server/integrations/registry.test.ts src/server/app.integrations.test.ts src/server/config`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/integrations/registry.ts src/server/config/schema.ts src/server/integrations/registry.test.ts src/server/app.integrations.test.ts
+git commit -m "feat(server): add bookmarks integration type and widget schema"
+```
+
+---
+
+### Task 2: Favicon resolver endpoint
+
+**Files:**
+- Create: `src/server/integrations/favicon.ts`
+- Create: `src/server/integrations/favicon.test.ts`
+- Modify: `src/server/app.ts` (add route near the other `/api` GETs, ~line 63)
+
+**Interfaces:**
+- Produces: `resolveFavicon(pageUrl: string): Promise<{ icon: string | null }>`; route `GET /api/favicon?url=<url>` returning that shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/integrations/favicon.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from 'bun:test';
+import { resolveFavicon } from './favicon';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function mockHtml(html: string) {
+  globalThis.fetch = (async () =>
+    new Response(html, { headers: { 'content-type': 'text/html' } })) as typeof fetch;
+}
+
+describe('resolveFavicon', () => {
+  it('parses <link rel="icon"> and resolves to an absolute URL', async () => {
+    mockHtml('<html><head><link rel="icon" href="/assets/fav.png"></head></html>');
+    const out = await resolveFavicon('https://example.com/dashboard');
+    expect(out.icon).toBe('https://example.com/assets/fav.png');
+  });
+
+  it('falls back to /favicon.ico when no link tag is present', async () => {
+    mockHtml('<html><head></head></html>');
+    const out = await resolveFavicon('https://example.com/x/y');
+    expect(out.icon).toBe('https://example.com/favicon.ico');
+  });
+
+  it('returns null icon when the URL is invalid', async () => {
+    const out = await resolveFavicon('not a url');
+    expect(out.icon).toBeNull();
+  });
+
+  it('returns null icon when the fetch throws', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network');
+    }) as typeof fetch;
+    const out = await resolveFavicon('https://example.com');
+    expect(out.icon).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test src/server/integrations/favicon.test.ts`
+Expected: FAIL — `Cannot find module './favicon'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `src/server/integrations/favicon.ts`:
+
+```ts
+import { TIMEOUT_MS } from './http';
+
+// ponytail: regex parse, not a full HTML parser — swap in a parser if it misses real-world sites
+const LINK_ICON_RE =
+  /<link[^>]+rel=["'][^"']*\bicon\b[^"']*["'][^>]*>/i;
+const HREF_RE = /href=["']([^"']+)["']/i;
+
+export async function resolveFavicon(pageUrl: string): Promise<{ icon: string | null }> {
+  let base: URL;
+  try {
+    base = new URL(pageUrl);
+    if (base.protocol !== 'http:' && base.protocol !== 'https:') return { icon: null };
+  } catch {
+    return { icon: null };
+  }
+
+  const fallback = new URL('/favicon.ico', base).href;
+
+  try {
+    const res = await fetch(base.href, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: 'follow',
+    });
+    if (!res.ok) return { icon: fallback };
+    const html = await res.text();
+    const tag = LINK_ICON_RE.exec(html);
+    const href = tag ? HREF_RE.exec(tag[0])?.[1] : undefined;
+    if (href) {
+      try {
+        return { icon: new URL(href, base).href };
+      } catch {
+        return { icon: fallback };
+      }
+    }
+    return { icon: fallback };
+  } catch {
+    // unreachable host / timeout: still offer the conventional path
+    return { icon: fallback };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test src/server/integrations/favicon.test.ts`
+Expected: PASS. (The "invalid URL" case returns null before fetching; the "fetch throws" case is caught and returns the fallback path computed from a *valid* base — note: for the throw test the URL `https://example.com` is valid, so it returns `https://example.com/favicon.ico`, not null. Adjust that assertion in Step 1 to `expect(out.icon).toBe('https://example.com/favicon.ico')` before running.)
+
+> NOTE TO IMPLEMENTER: In Step 1, change the last test's assertion to `expect(out.icon).toBe('https://example.com/favicon.ico')` to match the fail-soft fallback behavior (a valid base URL always yields the conventional `/favicon.ico` path even when the page fetch fails). Only a syntactically invalid URL yields `null`.
+
+- [ ] **Step 5: Add the route**
+
+In `src/server/app.ts`, add near the other `/api` GET routes (e.g. after line 63) and import at the top:
+
+```ts
+// top of file with other imports:
+import { resolveFavicon } from './integrations/favicon';
+
+// with the routes:
+app.get('/api/favicon', async (c) => {
+  const url = c.req.query('url');
+  if (!url) return c.json({ icon: null });
+  return c.json(await resolveFavicon(url));
+});
+```
+
+- [ ] **Step 6: Verify the route works**
+
+Run: `bun test src/server/integrations/favicon.test.ts && bun run build`
+Expected: tests PASS, build succeeds (typecheck clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/integrations/favicon.ts src/server/integrations/favicon.test.ts src/server/app.ts
+git commit -m "feat(server): add favicon resolver endpoint"
+```
+
+---
+
+### Task 3: Backup export + restore
+
+**Files:**
+- Modify: `src/server/db.ts` (add `replaceAllIntegrations`, ~after line 261)
+- Modify: `src/server/app.ts` (add `/api/backup`, `/api/restore`)
+- Create: `src/server/backup.test.ts`
+
+**Interfaces:**
+- Consumes: `listIntegrations()`, `getSetting('dashboard')`, `setSetting`, `db`, `IntegrationRow` (db.ts); `reloadConfig()` (config/loader.ts); `DashboardSchema` (config/schema.ts).
+- Produces: `replaceAllIntegrations(rows: IntegrationRow[]): void`; `GET /api/backup` → `{version:1; exportedAt:string; dashboard:object; integrations:IntegrationRow[]}`; `POST /api/restore` → `{ok:true}` or `{error}` (400).
+
+- [ ] **Step 1: Write the db helper test (failing)**
+
+Create `src/server/backup.test.ts`:
+
+```ts
+import { expect, test } from 'bun:test';
+import { createIntegration, deleteIntegration, listIntegrations, replaceAllIntegrations } from './db';
+
+const TAG = '__test_backup__';
+
+function cleanup() {
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(TAG))) deleteIntegration(r.id);
+}
+
+test('replaceAllIntegrations wipes then restores rows preserving ids', () => {
+  cleanup();
+  // snapshot current rows so we can restore the DB after the test
+  const original = listIntegrations();
+  try {
+    const restored = [
+      { id: 9001, name: `${TAG}a`, type: 'radarr', config: { url: 'http://a' }, enabled: true, refreshSeconds: 60 },
+      { id: 9002, name: `${TAG}b`, type: 'sonarr', config: {}, enabled: false, refreshSeconds: null },
+    ];
+    replaceAllIntegrations(restored);
+    const after = listIntegrations();
+    expect(after.length).toBe(2);
+    expect(after.find((r) => r.id === 9001)?.name).toBe(`${TAG}a`);
+    expect(after.find((r) => r.id === 9001)?.config).toEqual({ url: 'http://a' });
+    expect(after.find((r) => r.id === 9002)?.enabled).toBe(false);
+  } finally {
+    // restore the original integrations table
+    replaceAllIntegrations(original);
+  }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test src/server/backup.test.ts`
+Expected: FAIL — `replaceAllIntegrations` is not exported.
+
+- [ ] **Step 3: Implement the db helper**
+
+In `src/server/db.ts`, add at the end of the file:
+
+```ts
+export function replaceAllIntegrations(rows: IntegrationRow[]): void {
+  const tx = db.transaction((list: IntegrationRow[]) => {
+    db.query('DELETE FROM integrations').run();
+    const stmt = db.query(
+      'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds) VALUES ($id,$name,$type,$config,$enabled,$rs)',
+    );
+    for (const r of list) {
+      stmt.run({
+        $id: r.id,
+        $name: r.name,
+        $type: r.type,
+        $config: JSON.stringify(r.config),
+        $enabled: r.enabled ? 1 : 0,
+        $rs: r.refreshSeconds,
+      });
+    }
+  });
+  tx(rows);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test src/server/backup.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the endpoint tests (failing)**
+
+Append to `src/server/backup.test.ts`:
+
+```ts
+import { app } from './app';
+
+test('GET /api/backup returns version, dashboard, and integrations', async () => {
+  const res = await app.request('/api/backup');
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as any;
+  expect(body.version).toBe(1);
+  expect(body.dashboard).toBeDefined();
+  expect(Array.isArray(body.integrations)).toBe(true);
+});
+
+test('POST /api/restore rejects a malformed payload with 400 and leaves the DB intact', async () => {
+  const before = listIntegrations().length;
+  const res = await app.request('/api/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ version: 1, dashboard: { nope: true }, integrations: [] }),
+  });
+  expect(res.status).toBe(400);
+  expect(listIntegrations().length).toBe(before);
+});
+
+test('POST /api/restore round-trips a valid backup', async () => {
+  const original = await (await app.request('/api/backup')).json();
+  try {
+    const res = await app.request('/api/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(original),
+    });
+    expect(res.status).toBe(200);
+    const again = await (await app.request('/api/backup')).json();
+    expect(again.integrations.length).toBe(original.integrations.length);
+  } finally {
+    // ensure DB returns to the original snapshot regardless
+    await app.request('/api/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(original),
+    });
+  }
+});
+```
+
+- [ ] **Step 6: Run to verify the new endpoint tests fail**
+
+Run: `bun test src/server/backup.test.ts`
+Expected: FAIL — `/api/backup` and `/api/restore` are 404.
+
+- [ ] **Step 7: Implement the endpoints**
+
+In `src/server/app.ts`, add imports and routes:
+
+```ts
+// imports (merge with existing):
+import { z } from 'zod';
+import {
+  getSetting,
+  listIntegrations,
+  replaceAllIntegrations,
+  setSetting,
+} from './db';
+import { DashboardSchema } from './config/schema';
+import { reloadConfig } from './config/loader';
+
+// --- backup / restore ---
+app.get('/api/backup', (c) => {
+  const dashboardRaw = getSetting('dashboard');
+  const dashboard = dashboardRaw ? JSON.parse(dashboardRaw) : null;
+  const body = {
+    version: 1 as const,
+    exportedAt: new Date().toISOString(),
+    dashboard,
+    integrations: listIntegrations(),
+  };
+  c.header('Content-Type', 'application/json');
+  c.header(
+    'Content-Disposition',
+    `attachment; filename="labby-backup-${new Date().toISOString().slice(0, 10)}.json"`,
+  );
+  return c.body(JSON.stringify(body, null, 2));
+});
+
+const RestoreSchema = z.object({
+  version: z.literal(1),
+  exportedAt: z.string().optional(),
+  dashboard: DashboardSchema,
+  integrations: z.array(
+    z.object({
+      id: z.number().int(),
+      name: z.string(),
+      type: z.string(),
+      config: z.record(z.unknown()),
+      enabled: z.boolean(),
+      refreshSeconds: z.number().int().nullable(),
+    }),
+  ),
+});
+
+app.post('/api/restore', async (c) => {
+  const json = await c.req.json().catch(() => null);
+  const parsed = RestoreSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid backup file' }, 400);
+  }
+  const { dashboard, integrations } = parsed.data;
+  replaceAllIntegrations(integrations);
+  setSetting('dashboard', JSON.stringify(dashboard, null, 2));
+  reloadConfig();
+  return c.json({ ok: true });
+});
+```
+
+> NOTE: `replaceAllIntegrations` is already its own transaction; `setSetting` runs immediately after. If the integrations insert throws (bad data), it rolls back inside the helper and the dashboard write never runs.
+
+- [ ] **Step 8: Run the full backup test file**
+
+Run: `bun test src/server/backup.test.ts`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 9: Run the whole server suite + build**
+
+Run: `bun test && bun run build`
+Expected: all PASS, build clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/server/db.ts src/server/app.ts src/server/backup.test.ts
+git commit -m "feat(server): add full backup export and restore endpoints"
+```
+
+---
+
+### Task 4: Bookmarks widget (frontend render)
+
+**Files:**
+- Modify: `src/web/src/lib/stores.ts` (add `BookmarksData` type, ~after line 192)
+- Modify: `src/web/src/lib/types.ts` (add bookmarks to `Widget` union, ~line 29)
+- Create: `src/web/src/widgets/Bookmarks.svelte`
+- Modify: `src/web/src/components/WidgetHost.svelte` (import + branch)
+
+**Interfaces:**
+- Consumes: `getStore(integrationId)`, `WidgetState<T>` (stores.ts); `Icon.svelte`.
+- Produces: `BookmarksData = { links: Array<{ title:string; url:string; icon?:string }> }`; web `Widget` variant `{ type:'bookmarks'; title:string; integrationId:number }`; `Bookmarks.svelte` component with props `{ title:string; integrationId:number }`.
+
+- [ ] **Step 1: Add the data type**
+
+In `src/web/src/lib/stores.ts`, add after the `FeedData` type (~line 192):
+
+```ts
+export type BookmarkLink = { title: string; url: string; icon?: string };
+export type BookmarksData = { links: BookmarkLink[] };
+```
+
+- [ ] **Step 2: Add the web Widget variant**
+
+In `src/web/src/lib/types.ts`, add to the `Widget` union (after the `speedtest` member, line ~29):
+
+```ts
+  | { type: 'bookmarks'; title: string; integrationId: number };
+```
+
+(Move the trailing `;` so the union stays valid — the previous last member ended with `;`.)
+
+- [ ] **Step 3: Create the widget component**
+
+Create `src/web/src/widgets/Bookmarks.svelte` (mirrors the store-subscription + state pattern of `Feed.svelte`):
+
+```svelte
+<script lang="ts">
+  import Icon from '../components/Icon.svelte';
+  import { getStore, type BookmarksData, type WidgetState } from '$lib/stores';
+
+  let { title, integrationId }: { title: string; integrationId: number } = $props();
+
+  const store = $derived(getStore(integrationId));
+  const state = $derived($store as WidgetState<BookmarksData>);
+  const links = $derived(state.data?.links ?? []);
+</script>
+
+<section class="card">
+  <div class="chead">
+    <span class="ti">
+      <span class="ibox"><Icon icon="lucide:layout-grid" fallback="layout-grid" size={18} /></span>
+      {title}
+    </span>
+    {#if links.length}<span class="meta">{links.length}</span>{/if}
+  </div>
+
+  {#if state.loading && !state.data}
+    <div class="skeleton" style="height:96px"></div>
+  {:else if state.error}
+    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+  {:else if links.length === 0}
+    <p class="state-msg">No bookmarks</p>
+  {:else}
+    <div class="bm-grid">
+      {#each links as l}
+        <a class="bm-tile" href={l.url} target="_blank" rel="noopener">
+          <span class="bm-ico"><Icon icon={l.icon ?? ''} fallback="globe" size={22} /></span>
+          <span class="bm-label">{l.title}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .bm-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+    gap: 8px;
+  }
+  .bm-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 8px;
+    border-radius: var(--radius, 10px);
+    background: var(--surface-2, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    text-decoration: none;
+    transition: background 0.15s ease;
+  }
+  .bm-tile:hover {
+    background: var(--surface-3, rgba(127, 127, 127, 0.16));
+  }
+  .bm-label {
+    font-size: 0.78rem;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .bm-tile { transition: none; }
+  }
+</style>
+```
+
+- [ ] **Step 4: Wire it into WidgetHost**
+
+In `src/web/src/components/WidgetHost.svelte`: add the import near the other widget imports:
+
+```ts
+  import Bookmarks from '../widgets/Bookmarks.svelte';
+```
+
+And add the branch before the closing `{/if}` (after the `speedtest` branch, line ~69):
+
+```svelte
+{:else if widget.type === 'bookmarks'}
+  <Bookmarks title={widget.title} integrationId={widget.integrationId} />
+```
+
+- [ ] **Step 5: Build to typecheck**
+
+Run: `bun run build`
+Expected: build succeeds, no TS errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/src/lib/stores.ts src/web/src/lib/types.ts src/web/src/widgets/Bookmarks.svelte src/web/src/components/WidgetHost.svelte
+git commit -m "feat(web): add bookmarks widget rendering"
+```
+
+---
+
+### Task 5: Settings — links editor + favicon auto-fetch
+
+**Files:**
+- Modify: `src/web/src/Settings.svelte` (script: state helpers + `cleanConfig`; template: list-field branch; `TYPE_ICONS`)
+
+**Interfaces:**
+- Consumes: `formConfig` state, `GET /api/favicon` (Task 2).
+- Produces: a `links` list editor for the bookmarks integration type; favicon populated into a link's `icon` on URL blur when empty.
+
+- [ ] **Step 1: Add the TYPE_ICONS entry**
+
+In `src/web/src/Settings.svelte`, add to the `TYPE_ICONS` map:
+
+```ts
+    bookmarks: 'lucide:layout-grid',
+```
+
+- [ ] **Step 2: Add the links editor helpers**
+
+In the `<script>` block (near the `sites`/`addSite` helpers), add:
+
+```ts
+  type LinkForm = { title?: string; url?: string; icon?: string };
+  function links(key: string): LinkForm[] {
+    const v = formConfig[key];
+    return Array.isArray(v) ? (v as LinkForm[]) : [];
+  }
+  function addLink(key: string) {
+    formConfig = { ...formConfig, [key]: [...links(key), { title: '', url: '', icon: '' }] };
+  }
+  function removeLink(key: string, i: number) {
+    formConfig = { ...formConfig, [key]: links(key).filter((_, idx) => idx !== i) };
+  }
+  function updateLink(key: string, i: number, patch: Partial<LinkForm>) {
+    formConfig = {
+      ...formConfig,
+      [key]: links(key).map((l, idx) => (idx === i ? { ...l, ...patch } : l)),
+    };
+  }
+  async function fetchFavicon(key: string, i: number) {
+    const link = links(key)[i];
+    if (!link?.url?.trim() || link.icon?.trim()) return;
+    try {
+      const res = await fetch(`/api/favicon?url=${encodeURIComponent(link.url.trim())}`);
+      const data = (await res.json()) as { icon: string | null };
+      if (data.icon) updateLink(key, i, { icon: data.icon });
+    } catch {
+      /* leave icon empty — falls back to a glyph */
+    }
+  }
+```
+
+- [ ] **Step 3: Add the `links` branch to `cleanConfig`**
+
+In the `cleanConfig` function's `for (const [k, v] …)` loop, add a branch alongside the `sites` / `icsUrls` branches:
+
+```ts
+      } else if (k === 'links' && Array.isArray(v)) {
+        out[k] = (v as LinkForm[])
+          .map((l) => ({
+            title: (l.title ?? '').trim() || (l.url ?? '').trim(),
+            url: (l.url ?? '').trim(),
+            ...(l.icon?.trim() ? { icon: l.icon.trim() } : {}),
+          }))
+          .filter((l) => l.url);
+```
+
+- [ ] **Step 4: Add the template branch for the links field**
+
+In the form template, where list fields are dispatched (`{#if field.key === 'sites'} … {:else if field.key === 'icsUrls'} …`), add a branch for `links`:
+
+```svelte
+          {:else if field.key === 'links'}
+            <div class="sites-editor">
+              {#each links(field.key) as l, i}
+                <div class="site-row">
+                  <input
+                    type="text"
+                    placeholder="Title"
+                    value={l.title ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { title: e.currentTarget.value })}
+                  />
+                  <input
+                    type="text"
+                    placeholder="https://service.lan"
+                    value={l.url ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { url: e.currentTarget.value })}
+                    onblur={() => fetchFavicon(field.key, i)}
+                  />
+                  <input
+                    type="text"
+                    placeholder="Icon (auto)"
+                    value={l.icon ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { icon: e.currentTarget.value })}
+                  />
+                  <span class="ibox"><Icon icon={l.icon ?? ''} fallback="globe" size={18} /></span>
+                  <button type="button" class="btn-icon danger" onclick={() => removeLink(field.key, i)} aria-label="Remove link" title="Remove link">
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              {/each}
+              <button type="button" class="btn-add-site" onclick={() => addLink(field.key)}>
+                <Plus size={14} /> Add link
+              </button>
+            </div>
+```
+
+> NOTE: reuse the existing `sites-editor` / `site-row` / `btn-add-site` classes already styled in this file. Confirm those class names exist in the monitor `sites` branch and match.
+
+- [ ] **Step 5: Build to typecheck**
+
+Run: `bun run build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Manual smoke (optional but recommended)**
+
+Run `bun run dev` and `cd src/web && bun run dev`; open the Vite URL → Manage Services → Add → Bookmarks. Add a link with a public URL (e.g. `https://github.com`), blur the URL field, confirm the icon auto-fills. Save. Place a `bookmarks` widget by exporting the dashboard (Task 6), adding a `{type:'bookmarks', title, integrationId:<new id>}` widget to a column, and importing — confirm the tile grid renders.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/src/Settings.svelte
+git commit -m "feat(web): add bookmarks links editor with favicon auto-fetch"
+```
+
+---
+
+### Task 6: Settings — export / import backup buttons
+
+**Files:**
+- Modify: `src/web/src/Settings.svelte` (template header + handlers)
+
+**Interfaces:**
+- Consumes: `GET /api/backup`, `POST /api/restore` (Task 3).
+- Produces: Export and Import buttons in the "Manage Services" header.
+
+- [ ] **Step 1: Add the handlers**
+
+In the `<script>` block of `src/web/src/Settings.svelte`, add:
+
+```ts
+  let importing = $state(false);
+  let fileInput = $state<HTMLInputElement | null>(null);
+
+  function exportBackup() {
+    window.location.href = '/api/backup';
+  }
+
+  async function onImportFile(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+    if (!confirm('This replaces ALL services and your dashboard layout with the backup’s contents. Continue?')) return;
+    importing = true;
+    error = null;
+    try {
+      const text = await file.text();
+      const res = await fetch('/api/restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: text,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Failed to restore backup');
+      }
+      window.location.reload();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to restore backup';
+    } finally {
+      importing = false;
+    }
+  }
+```
+
+- [ ] **Step 2: Add the buttons to the header**
+
+In the template, inside `.settings-bar` (after the `.settings-heading` div), add:
+
+```svelte
+    <div class="settings-actions">
+      <button type="button" class="btn-cancel" onclick={exportBackup} title="Download a full backup (includes credentials)">
+        Export backup
+      </button>
+      <button type="button" class="btn-cancel" onclick={() => fileInput?.click()} disabled={importing}>
+        {importing ? 'Importing…' : 'Import backup'}
+      </button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept="application/json"
+        style="display:none"
+        onchange={onImportFile}
+      />
+    </div>
+    <p class="settings-sub" style="margin-top:6px">⚠️ Backups contain plaintext credentials — store them securely.</p>
+```
+
+> NOTE: reuse the existing `btn-cancel` button class for styling consistency, or add a `.settings-actions { display:flex; gap:8px; }` rule if the layout needs it. Keep within the existing header markup.
+
+- [ ] **Step 3: Build to typecheck**
+
+Run: `bun run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual smoke**
+
+`bun run dev` + `cd src/web && bun run dev` → Manage Services → click **Export backup**, confirm a `labby-backup-<date>.json` downloads with `dashboard` + `integrations`. Edit it (e.g. add a bookmarks widget to a column), click **Import backup**, choose the file, confirm the dialog, confirm the page reloads with the change applied.
+
+- [ ] **Step 5: Final full check**
+
+Run: `bun test && bun run build`
+Expected: all server tests PASS, build clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/src/Settings.svelte
+git commit -m "feat(web): add backup export/import buttons to Manage Services"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 schema bookmarks variant → Task 1. ✓
+- §2 export `/api/backup` + restore `/api/restore` + `replaceAllIntegrations` + UI buttons → Task 3 + Task 6. ✓
+- §3 bookmarks registry type + render + editor → Task 1 (type), Task 4 (render), Task 5 (editor). ✓ (Spec's "one-time `/data` fetch" is satisfied by the existing `getStore`/`bootstrapStores` SSE path — no new endpoint, documented in Architecture.)
+- §4 favicon endpoint + frontend wiring + URL storage → Task 2 + Task 5. ✓
+- §5 tests: `backup.test.ts` (Task 3), `registry.test.ts` bookmarks (Task 1), `favicon.test.ts` (Task 2). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The two `NOTE` blocks point to a Step-1 assertion correction and class-name reuse — both concrete, not deferrals.
+
+**Type consistency:** `BookmarksData`/`BookmarkLink` (stores.ts) used by `Bookmarks.svelte`; `LinkForm` is the Settings editor shape and serializes to `{title,url,icon?}` matching `BookmarkLink`; `replaceAllIntegrations(rows: IntegrationRow[])` signature matches its caller in `/api/restore`; integration count `15→16` updated in `registry.test.ts` (2 spots) and `app.integrations.test.ts` (1 spot).
+
+**Known deviation from spec (intentional):** the favicon "fetch throws" test returns the `/favicon.ico` fallback (not `null`) because the resolver fails soft to the conventional path for any *valid* URL; only invalid URLs return `null`. Step 1/Step 4 of Task 2 call this out explicitly.

--- a/docs/superpowers/plans/2026-06-26-integration-driven-layout.md
+++ b/docs/superpowers/plans/2026-06-26-integration-driven-layout.md
@@ -1,0 +1,840 @@
+# Integration-Driven Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Labby's separate dashboard layout (pages/columns/widgets JSON); the dashboard becomes the ordered list of enabled integrations, each rendered as its widget, reordered by drag-and-drop on the config page.
+
+**Architecture:** Add a `position` column to `integrations`; render the board directly from `listIntegrations()`; move per-widget display options into each integration's `config`; shrink the stored dashboard to `{title, theme}`; a one-time migration folds the existing layout's order + options into the integrations so the live board survives.
+
+**Tech Stack:** Bun, Hono, Zod, bun:sqlite, Svelte 5 (runes), bun:test.
+
+## Global Constraints
+
+- TypeScript strict everywhere; validate untrusted input with Zod.
+- Server types (`src/server/...`) and web types (`src/web/src/lib/types.ts`, `stores.ts`) are duplicated by design — keep them in sync.
+- Integrations fail soft: `fetch` returns `Payload | {error}`, never throws.
+- Tests colocated, `bun:test`; endpoint tests use `app.request(path, opts)`; DB tests call db functions directly and clean up by unique name; `fetch` is mocked.
+- Single masonry flow; no pages, no columns. Order = `position ASC, id ASC`.
+- Drag reorder uses native HTML5 DnD — **no new dependency**.
+- Display options live in integration `config`: monitor `variant`(rows/tiles)+`style`(default/compact); `max` on qbittorrent, transmission, beszel, radarr, sonarr, reelward, reddit, hackernews, calendar; beszel `systems` retained.
+- Run server tests with `bun test`; build/typecheck frontend with `bun run build`.
+
+---
+
+### Task 1: `position` column, ordering, reorder helper
+
+**Files:**
+- Modify: `src/server/db.ts`
+- Test: `src/server/db.integrations.test.ts`
+
+**Interfaces:**
+- Produces: `IntegrationRow.position: number`; `listIntegrations()` ordered by `position, id`; `createIntegration` auto-assigns `position`; `reorderIntegrations(orderedIds: number[]): void`; `replaceAllIntegrations` inserts `position`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/server/db.integrations.test.ts`:
+
+```ts
+import { reorderIntegrations } from './db';
+
+test('position is assigned on create and returned in order', () => {
+  const tag = '__pos_test__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
+  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  try {
+    expect(typeof a.position).toBe('number');
+    expect(b.position).toBeGreaterThan(a.position);
+    reorderIntegrations([b.id, a.id]);
+    const ordered = listIntegrations().filter((r) => r.name.startsWith(tag));
+    expect(ordered[0].id).toBe(b.id);
+    expect(ordered[1].id).toBe(a.id);
+  } finally {
+    deleteIntegration(a.id);
+    deleteIntegration(b.id);
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/server/db.integrations.test.ts`
+Expected: FAIL — `reorderIntegrations` not exported / `position` undefined.
+
+- [ ] **Step 3: Add migration + column handling**
+
+In `src/server/db.ts`, add a migration to the `migrations` array (next version number after the current highest — currently 4, so use 5):
+
+```ts
+  {
+    version: 5,
+    name: 'integration_position',
+    up: `
+      ALTER TABLE integrations ADD COLUMN position INTEGER;
+      UPDATE integrations SET position = id WHERE position IS NULL;
+    `,
+  },
+```
+
+- [ ] **Step 4: Update `IntegrationRow`, `Raw`, `toRow`, CRUD, and add `reorderIntegrations`**
+
+In `src/server/db.ts`:
+
+Add `position: number;` to the `IntegrationRow` type and `position: number | null;` to the `Raw` type. Update `toRow`:
+
+```ts
+const toRow = (r: Raw): IntegrationRow => ({
+  id: r.id,
+  name: r.name,
+  type: r.type,
+  config: JSON.parse(r.config),
+  enabled: !!r.enabled,
+  refreshSeconds: r.refresh_seconds,
+  position: r.position ?? r.id,
+});
+```
+
+Change `listIntegrations`:
+
+```ts
+export function listIntegrations(): IntegrationRow[] {
+  return (db.query('SELECT * FROM integrations ORDER BY position, id').all() as Raw[]).map(toRow);
+}
+```
+
+Change `createIntegration` to assign the next position (insert then it gets one). Replace the INSERT to include position:
+
+```ts
+export function createIntegration(input: Omit<IntegrationRow, 'id' | 'position'>): IntegrationRow {
+  const nextPos =
+    (db.query('SELECT COALESCE(MAX(position), 0) + 1 AS p FROM integrations').get() as { p: number }).p;
+  const info = db
+    .query(
+      'INSERT INTO integrations (name, type, config, enabled, refresh_seconds, position) VALUES ($name,$type,$config,$enabled,$rs,$pos)',
+    )
+    .run({
+      $name: input.name,
+      $type: input.type,
+      $config: JSON.stringify(input.config),
+      $enabled: input.enabled ? 1 : 0,
+      $rs: input.refreshSeconds,
+      $pos: nextPos,
+    });
+  return getIntegration(Number(info.lastInsertRowid)) as IntegrationRow;
+}
+```
+
+> NOTE: `createIntegration`'s param type changes to `Omit<IntegrationRow, 'id' | 'position'>`. Check callers: `app.ts` `POST /api/integrations` builds the object from the request body — it does not pass `position`, so it already satisfies the new type. `updateIntegration` takes `Omit<IntegrationRow, 'id'>` — leave it; it will receive `position` from the edited row, which is fine (it does not write position, see below). To keep `updateIntegration` from dropping position, leave its SQL as-is (it never touched position; position is preserved across updates because the column isn't in its UPDATE statement).
+
+Add `reorderIntegrations`:
+
+```ts
+export function reorderIntegrations(orderedIds: number[]): void {
+  const tx = db.transaction((ids: number[]) => {
+    const stmt = db.query('UPDATE integrations SET position = $pos WHERE id = $id');
+    ids.forEach((id, idx) => stmt.run({ $id: id, $pos: idx }));
+  });
+  tx(orderedIds);
+}
+```
+
+Update `replaceAllIntegrations` (added in the earlier backup feature) to insert `position`:
+
+```ts
+export function replaceAllIntegrations(rows: IntegrationRow[]): void {
+  const tx = db.transaction((list: IntegrationRow[]) => {
+    db.query('DELETE FROM integrations').run();
+    const stmt = db.query(
+      'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds, position) VALUES ($id,$name,$type,$config,$enabled,$rs,$pos)',
+    );
+    for (const r of list) {
+      stmt.run({
+        $id: r.id,
+        $name: r.name,
+        $type: r.type,
+        $config: JSON.stringify(r.config),
+        $enabled: r.enabled ? 1 : 0,
+        $rs: r.refreshSeconds,
+        $pos: r.position ?? r.id,
+      });
+    }
+  });
+  tx(rows);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test src/server/db.integrations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run full suite (catch caller breakage)**
+
+Run: `bun test`
+Expected: PASS (existing create/list/backup tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/db.ts src/server/db.integrations.test.ts
+git commit -m "feat(server): add integration position column, ordering, and reorder helper"
+```
+
+---
+
+### Task 2: Shrink dashboard schema + add display-option registry fields
+
+**Files:**
+- Modify: `src/server/config/schema.ts`
+- Modify: `src/server/integrations/registry.ts`
+- Test: `src/server/config/schema.test.ts`, `src/server/integrations/registry.test.ts`
+
+**Interfaces:**
+- Produces: `DashboardSchema` = `{ title, theme }`; `Dashboard` type without `pages`; registry types gain display fields.
+- Removes: `WidgetSchema`, `ColumnSchema`, `PageSchema`, `Widget` type.
+
+- [ ] **Step 1: Update schema tests (failing)**
+
+In `src/server/config/schema.test.ts`, add (and remove any test that asserts `pages` is required):
+
+```ts
+import { DashboardSchema } from './schema';
+
+test('DashboardSchema accepts {title, theme} without pages', () => {
+  const parsed = DashboardSchema.parse({ title: 'Home', theme: { default: 'dark' } });
+  expect(parsed.title).toBe('Home');
+});
+
+test('DashboardSchema ignores a legacy pages field', () => {
+  const parsed = DashboardSchema.parse({ title: 'X', theme: { default: 'system' }, pages: [{ junk: true }] });
+  expect((parsed as any).pages).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test src/server/config/schema.test.ts`
+Expected: FAIL (current schema requires `pages`).
+
+- [ ] **Step 3: Shrink the schema**
+
+In `src/server/config/schema.ts`:
+- Delete `WidgetSchema`, `ColumnSchema`, `PageSchema`, and the `Widget` type export.
+- Keep `SiteSchema`, `ThemeConfigSchema`, `ThemeSchema`, `LayoutSchema`, `DensitySchema` (theme + monitor config still use them).
+- Replace `DashboardSchema`:
+
+```ts
+export const DashboardSchema = z.object({
+  title: z.string().default('Labby'),
+  theme: ThemeConfigSchema.default({ default: 'system', layout: 'masonry' }),
+});
+
+export type Dashboard = z.infer<typeof DashboardSchema>;
+export type Site = z.infer<typeof SiteSchema>;
+```
+
+(Zod strips unknown keys by default, so a stored dashboard still carrying `pages` parses cleanly with `pages` dropped.)
+
+- [ ] **Step 4: Run schema tests**
+
+Run: `bun test src/server/config/schema.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add display-option fields to the registry (failing test first)**
+
+In `src/server/integrations/registry.test.ts`, add:
+
+```ts
+test('monitor exposes variant and style display fields', () => {
+  const keys = INTEGRATIONS.monitor.fields.map((f) => f.key);
+  expect(keys).toContain('variant');
+  expect(keys).toContain('style');
+});
+
+test('feed/arr/calendar/download/beszel types expose a max field', () => {
+  for (const t of ['qbittorrent', 'transmission', 'beszel', 'radarr', 'sonarr', 'reelward', 'reddit', 'hackernews', 'calendar'] as const) {
+    expect(INTEGRATIONS[t].fields.map((f) => f.key)).toContain('max');
+  }
+});
+```
+
+- [ ] **Step 6: Run to verify failure**
+
+Run: `bun test src/server/integrations/registry.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 7: Add the fields**
+
+In `src/server/integrations/registry.ts`, add to the `fields` arrays:
+- `monitor.fields`: append `{ key: 'variant', label: 'Display', kind: 'select', options: ['rows', 'tiles'] }` and `{ key: 'style', label: 'Density', kind: 'select', options: ['default', 'compact'] }`.
+- `qbittorrent.fields`, `transmission.fields`: append `{ key: 'max', label: 'Max items', kind: 'number' }`.
+- `beszel.fields`: append `{ key: 'max', label: 'Max systems', kind: 'number' }`.
+- `radarr.fields`, `sonarr.fields`, `reelward.fields`: append `{ key: 'max', label: 'Max items', kind: 'number' }`.
+- `reddit.fields`, `hackernews.fields`: append `{ key: 'max', label: 'Max items', kind: 'number' }`.
+- `calendar.fields`: append `{ key: 'max', label: 'Max events', kind: 'number' }`.
+
+(`hackernews.fields` is currently `[]` — make it `[{ key: 'max', label: 'Max items', kind: 'number' }]`.)
+
+- [ ] **Step 8: Run registry + full suite**
+
+Run: `bun test src/server/integrations/registry.test.ts && bun test`
+Expected: PASS. (If any test imported `Widget`/`WidgetSchema` from schema, update it; grep `WidgetSchema` to confirm none remain: `grep -rn "WidgetSchema\|PageSchema\|ColumnSchema" src/server` should return nothing.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/config/schema.ts src/server/integrations/registry.ts src/server/config/schema.test.ts src/server/integrations/registry.test.ts
+git commit -m "feat(server): shrink dashboard schema to title+theme, add display-option fields"
+```
+
+---
+
+### Task 3: Reorder endpoint + restore schema update
+
+**Files:**
+- Modify: `src/server/app.ts`
+- Test: `src/server/backup.test.ts` (append) or a new `src/server/app.reorder.test.ts`
+
+**Interfaces:**
+- Consumes: `reorderIntegrations`, `listIntegrations` (Task 1); `DashboardSchema` (Task 2).
+- Produces: `POST /api/integrations/reorder` body `{ ids: number[] }` → `{ ok: true }`; `RestoreSchema` integrations rows include `position`.
+
+- [ ] **Step 1: Write the endpoint test (failing)**
+
+Create `src/server/app.reorder.test.ts`:
+
+```ts
+import { expect, test } from 'bun:test';
+import { app } from './app';
+import { createIntegration, deleteIntegration, listIntegrations } from './db';
+
+test('POST /api/integrations/reorder sets the given order', async () => {
+  const tag = '__reorder_api__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
+  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  try {
+    const res = await app.request('/api/integrations/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [b.id, a.id] }),
+    });
+    expect(res.status).toBe(200);
+    const ordered = listIntegrations().filter((r) => r.name.startsWith(tag));
+    expect(ordered[0].id).toBe(b.id);
+  } finally {
+    deleteIntegration(a.id);
+    deleteIntegration(b.id);
+  }
+});
+
+test('POST /api/integrations/reorder rejects a non-array body with 400', async () => {
+  const res = await app.request('/api/integrations/reorder', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids: 'nope' }),
+  });
+  expect(res.status).toBe(400);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test src/server/app.reorder.test.ts`
+Expected: FAIL — route is 404.
+
+- [ ] **Step 3: Add the route + import**
+
+In `src/server/app.ts`, add `reorderIntegrations` to the `./db` import, and add the route near the other `/api/integrations` routes:
+
+```ts
+app.post('/api/integrations/reorder', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = z.object({ ids: z.array(z.number().int()) }).safeParse(body);
+  if (!parsed.success) return c.json({ error: 'Invalid reorder payload' }, 400);
+  reorderIntegrations(parsed.data.ids);
+  return c.json({ ok: true });
+});
+```
+
+- [ ] **Step 4: Update RestoreSchema to carry position**
+
+In `src/server/app.ts`, in `RestoreSchema`, add `position` to the integrations row object:
+
+```ts
+  integrations: z.array(
+    z.object({
+      id: z.number().int(),
+      name: z.string(),
+      type: z.string(),
+      config: z.record(z.unknown()),
+      enabled: z.boolean(),
+      refreshSeconds: z.number().int().nullable(),
+      position: z.number().int().optional(),
+    }),
+  ),
+```
+
+(`position` optional tolerates backups taken before this change; `replaceAllIntegrations` falls back to `id`.)
+
+- [ ] **Step 5: Run reorder + backup tests + full suite**
+
+Run: `bun test src/server/app.reorder.test.ts src/server/backup.test.ts && bun test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/app.ts src/server/app.reorder.test.ts
+git commit -m "feat(server): add integration reorder endpoint, carry position in restore"
+```
+
+---
+
+### Task 4: One-time layout→integrations migration
+
+**Files:**
+- Create: `src/server/config/migrate-layout.ts`
+- Create: `src/server/config/migrate-layout.test.ts`
+- Modify: `src/server/index.ts` (invoke once at startup)
+
+**Interfaces:**
+- Consumes: `getSetting`, `setSetting`, `listIntegrations`, `updateIntegration`, `reorderIntegrations` (db.ts).
+- Produces: `migrateLayoutToIntegrations(): void` — idempotent (guarded by a `settings` flag `layout_migrated`).
+
+- [ ] **Step 1: Write the migration test (failing)**
+
+Create `src/server/config/migrate-layout.test.ts`:
+
+```ts
+import { expect, test } from 'bun:test';
+import { createIntegration, deleteIntegration, getIntegration, getSetting, listIntegrations, setSetting, deleteSetting } from '../db';
+import { migrateLayoutToIntegrations } from './migrate-layout';
+
+test('migration folds widget options + order into integrations and rewrites dashboard', () => {
+  const tag = '__migrate__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const savedDash = getSetting('dashboard');
+  const savedFlag = getSetting('layout_migrated');
+  deleteSetting('layout_migrated');
+
+  const m = createIntegration({ name: `${tag}mon`, type: 'monitor', config: { sites: [] }, enabled: true, refreshSeconds: null });
+  const f = createIntegration({ name: `${tag}feed`, type: 'reddit', config: { subreddits: ['x'] }, enabled: true, refreshSeconds: null });
+
+  // legacy dashboard: feed first, monitor second; options on widgets
+  setSetting('dashboard', JSON.stringify({
+    title: 'My Board',
+    theme: { default: 'dark' },
+    pages: [{ name: 'Home', columns: [{ size: 'full', widgets: [
+      { type: 'reddit', integrationId: f.id, max: 9 },
+      { type: 'monitor', integrationId: m.id, variant: 'tiles', style: 'compact' },
+    ] }] }],
+  }));
+
+  try {
+    migrateLayoutToIntegrations();
+    // options merged into config
+    expect(getIntegration(f.id)?.config.max).toBe(9);
+    expect(getIntegration(m.id)?.config.variant).toBe('tiles');
+    expect(getIntegration(m.id)?.config.style).toBe('compact');
+    // order: feed (first widget) before monitor
+    expect(getIntegration(f.id)!.position).toBeLessThan(getIntegration(m.id)!.position);
+    // dashboard rewritten without pages, title/theme kept
+    const dash = JSON.parse(getSetting('dashboard') as string);
+    expect(dash.pages).toBeUndefined();
+    expect(dash.title).toBe('My Board');
+    expect(dash.theme.default).toBe('dark');
+    // idempotent: second run is a no-op (flag set)
+    expect(getSetting('layout_migrated')).toBe('1');
+  } finally {
+    deleteIntegration(m.id);
+    deleteIntegration(f.id);
+    if (savedDash !== null) setSetting('dashboard', savedDash);
+    if (savedFlag !== null) setSetting('layout_migrated', savedFlag); else deleteSetting('layout_migrated');
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test src/server/config/migrate-layout.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the migration**
+
+Create `src/server/config/migrate-layout.ts`:
+
+```ts
+import { getSetting, listIntegrations, reorderIntegrations, setSetting, updateIntegration } from '../db';
+
+const DISPLAY_KEYS = ['max', 'variant', 'style', 'systems'] as const;
+
+// One-time: fold the legacy pages/columns/widgets layout into the integrations
+// (display options -> config, widget order -> position), then rewrite the
+// dashboard row to just {title, theme}. Guarded by the `layout_migrated` flag.
+export function migrateLayoutToIntegrations(): void {
+  if (getSetting('layout_migrated') === '1') return;
+
+  const raw = getSetting('dashboard');
+  if (!raw) {
+    setSetting('layout_migrated', '1');
+    return;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    setSetting('layout_migrated', '1');
+    return;
+  }
+
+  if (Array.isArray(parsed?.pages)) {
+    const byId = new Map(listIntegrations().map((r) => [r.id, r]));
+    const orderedIds: number[] = [];
+
+    for (const page of parsed.pages) {
+      for (const col of page?.columns ?? []) {
+        for (const w of col?.widgets ?? []) {
+          const row = byId.get(w?.integrationId);
+          if (!row) continue;
+          if (!orderedIds.includes(row.id)) orderedIds.push(row.id);
+          const merged = { ...row.config };
+          for (const k of DISPLAY_KEYS) {
+            if (w[k] !== undefined && merged[k] === undefined) merged[k] = w[k];
+          }
+          updateIntegration(row.id, { ...row, config: merged });
+        }
+      }
+    }
+
+    // any integration not referenced by a widget keeps its place after the rest
+    for (const r of listIntegrations()) if (!orderedIds.includes(r.id)) orderedIds.push(r.id);
+    reorderIntegrations(orderedIds);
+  }
+
+  setSetting('dashboard', JSON.stringify({
+    title: parsed?.title ?? 'Labby',
+    theme: parsed?.theme ?? { default: 'system' },
+  }, null, 2));
+  setSetting('layout_migrated', '1');
+}
+```
+
+- [ ] **Step 4: Run migration test**
+
+Run: `bun test src/server/config/migrate-layout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Invoke at startup**
+
+In `src/server/index.ts`, import and call it once before the scheduler starts (after migrations run on db import). Add near the top of the startup sequence:
+
+```ts
+import { migrateLayoutToIntegrations } from './config/migrate-layout';
+// ... after imports / before initScheduler():
+migrateLayoutToIntegrations();
+```
+
+(Find the existing startup block that calls `loadConfig()` / `initScheduler()` and place the call before `loadConfig()` so the reload reads the rewritten dashboard.)
+
+- [ ] **Step 6: Run full suite + build**
+
+Run: `bun test && bun run build`
+Expected: PASS, build clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/config/migrate-layout.ts src/server/config/migrate-layout.test.ts src/server/index.ts
+git commit -m "feat(server): one-time migration folding layout into integrations"
+```
+
+---
+
+### Task 5: Frontend render from integrations (App, WidgetHost, Header, types)
+
+**Files:**
+- Modify: `src/web/src/lib/types.ts`
+- Modify: `src/web/src/components/WidgetHost.svelte`
+- Modify: `src/web/src/App.svelte`
+- Modify: `src/web/src/components/Header.svelte`
+
+**Interfaces:**
+- Consumes: `getStore`, `BookmarksData`/widget data types (stores.ts), `/api/integrations`.
+- Produces: `Dashboard = { title, theme }`; `IntegrationRow` with `position`; `WidgetHost` prop `{ integration }`.
+
+- [ ] **Step 1: Update web types**
+
+In `src/web/src/lib/types.ts`:
+- Delete the `Widget`, `Column`, `Page` types.
+- Replace `Dashboard`:
+
+```ts
+export type Dashboard = {
+  title: string;
+  theme: {
+    default: ThemeName;
+    layout: LayoutType;
+    density?: 'default' | 'compact';
+    customCss?: string;
+  };
+};
+```
+
+- Add `position: number;` to `IntegrationRow`.
+
+- [ ] **Step 2: Rewrite WidgetHost to key on the integration**
+
+Replace `src/web/src/components/WidgetHost.svelte` script + markup:
+
+```svelte
+<script lang="ts">
+  import Monitor from '../widgets/Monitor.svelte';
+  import Docker from '../widgets/Docker.svelte';
+  import Downloads from '../widgets/Downloads.svelte';
+  import AdGuard from '../widgets/AdGuard.svelte';
+  import Jellyfin from '../widgets/Jellyfin.svelte';
+  import Beszel from '../widgets/Beszel.svelte';
+  import Arr from '../widgets/Arr.svelte';
+  import Reelward from '../widgets/Reelward.svelte';
+  import Feed from '../widgets/Feed.svelte';
+  import Weather from '../widgets/Weather.svelte';
+  import Calendar from '../widgets/Calendar.svelte';
+  import Speedtest from '../widgets/Speedtest.svelte';
+  import Bookmarks from '../widgets/Bookmarks.svelte';
+  import type { IntegrationRow } from '$lib/types';
+
+  let { integration }: { integration: IntegrationRow } = $props();
+  const c = $derived(integration.config as Record<string, any>);
+  const id = $derived(integration.id);
+  const title = $derived(integration.name);
+</script>
+
+{#if integration.type === 'monitor'}
+  <Monitor {title} integrationId={id} style={c.style} variant={c.variant ?? 'rows'} headerIcon={c.variant === 'tiles' ? 'lucide:layout-grid' : 'lucide:activity'} />
+{:else if integration.type === 'docker'}
+  <Docker {title} integrationId={id} />
+{:else if integration.type === 'qbittorrent' || integration.type === 'transmission'}
+  <Downloads {title} integrationId={id} client={integration.type} max={c.max} />
+{:else if integration.type === 'adguard'}
+  <AdGuard {title} integrationId={id} />
+{:else if integration.type === 'jellyfin'}
+  <Jellyfin {title} integrationId={id} />
+{:else if integration.type === 'beszel'}
+  <Beszel {title} integrationId={id} systems={c.systems} max={c.max} />
+{:else if integration.type === 'radarr' || integration.type === 'sonarr'}
+  <Arr {title} integrationId={id} kind={integration.type} max={c.max} />
+{:else if integration.type === 'reelward'}
+  <Reelward {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'reddit'}
+  <Feed {title} integrationId={id} icon="di:reddit" fallback="message-square" max={c.max} />
+{:else if integration.type === 'hackernews'}
+  <Feed {title} integrationId={id} icon="di:hacker-news" fallback="flame" max={c.max} />
+{:else if integration.type === 'weather'}
+  <Weather {title} integrationId={id} />
+{:else if integration.type === 'calendar'}
+  <Calendar {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'speedtest'}
+  <Speedtest {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'bookmarks'}
+  <Bookmarks {title} integrationId={id} />
+{/if}
+```
+
+- [ ] **Step 3: Rewrite App.svelte to render the integration list**
+
+Replace `src/web/src/App.svelte`:
+
+```svelte
+<script lang="ts">
+  import WidgetHost from './components/WidgetHost.svelte';
+  import Header from './components/Header.svelte';
+  import { initStream } from '$lib/stores';
+  import type { Dashboard, IntegrationRow } from '$lib/types';
+  import { onMount } from 'svelte';
+
+  let { config }: { config: Dashboard } = $props();
+  let integrations = $state<IntegrationRow[]>([]);
+
+  const visible = $derived(
+    [...integrations].filter((r) => r.enabled).sort((a, b) => a.position - b.position || a.id - b.id),
+  );
+
+  onMount(() => {
+    void fetch('/api/integrations')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((rows: IntegrationRow[]) => {
+        integrations = rows;
+      });
+    return initStream();
+  });
+</script>
+
+<Header {config} {integrations} />
+
+<main class="page">
+  <div class="grid">
+    {#each visible as integration (integration.id)}
+      <WidgetHost {integration} />
+    {/each}
+  </div>
+</main>
+```
+
+- [ ] **Step 4: Fix Header — monitor IDs from integrations, drop layout radio**
+
+In `src/web/src/components/Header.svelte`:
+- Change props: `let { config, integrations = [] }: { config: Dashboard; integrations?: IntegrationRow[] } = $props();` and import `IntegrationRow` from `$lib/types`.
+- Replace the `monitorIds` derivation (the `for (const page of config.pages)` block) with:
+
+```ts
+  const monitorIds = $derived(
+    integrations.filter((r) => r.type === 'monitor' && r.enabled).map((r) => r.id),
+  );
+```
+
+- Remove the Layout radio group from the Customize modal (the `.settings-group` containing `name="layout"`), the `previewLayout` function, and the `layout` state — single masonry only. Leave `density`, `customCss`, `theme`. In `saveSettings`, drop `layout` from the POST body (or keep sending the current value; simpler to omit). `/api/theme` ignores missing layout.
+
+> NOTE: confirm no remaining reference to `config.pages` anywhere: `grep -rn "\.pages" src/web/src` must return nothing after this task.
+
+- [ ] **Step 5: Build to typecheck**
+
+Run: `bun run build`
+Expected: build succeeds, no TS/Svelte errors. If `grep -rn "\.pages" src/web/src` returns hits, fix them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/src/lib/types.ts src/web/src/components/WidgetHost.svelte src/web/src/App.svelte src/web/src/components/Header.svelte
+git commit -m "feat(web): render dashboard from ordered integrations, drop pages/columns"
+```
+
+---
+
+### Task 6: Drag-and-drop reordering on the config page
+
+**Files:**
+- Modify: `src/web/src/Settings.svelte`
+
+**Interfaces:**
+- Consumes: `POST /api/integrations/reorder` (Task 3); `rows` state (existing `IntegrationRow[]`).
+
+- [ ] **Step 1: Add reorder state + handler (script)**
+
+In `src/web/src/Settings.svelte` `<script>`, add:
+
+```ts
+  let dragIndex = $state<number | null>(null);
+
+  async function persistOrder() {
+    try {
+      await fetch('/api/integrations/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: rows.map((r) => r.id) }),
+      });
+    } catch {
+      /* order will resync on next load */
+    }
+  }
+
+  function onDragStart(i: number) {
+    dragIndex = i;
+  }
+  function onDragOver(e: DragEvent, i: number) {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === i) return;
+    const next = [...rows];
+    const [moved] = next.splice(dragIndex, 1);
+    next.splice(i, 0, moved);
+    rows = next;
+    dragIndex = i;
+  }
+  function onDrop() {
+    dragIndex = null;
+    void persistOrder();
+  }
+```
+
+- [ ] **Step 2: Make service cards draggable (template)**
+
+In the `{#each rows as row}` service-card loop, change the wrapper to track index and accept drag events, and add a handle. Replace the loop opening:
+
+```svelte
+      {#each rows as row, i (row.id)}
+        <div
+          class="svc-card"
+          class:dragging={dragIndex === i}
+          draggable="true"
+          ondragstart={() => onDragStart(i)}
+          ondragover={(e) => onDragOver(e, i)}
+          ondrop={onDrop}
+          ondragend={onDrop}
+        >
+          <div class="svc-head">
+            <span class="drag-handle" aria-hidden="true" title="Drag to reorder">⠿</span>
+            <span class="svc-mark"><Icon icon={TYPE_ICONS[row.type] ?? 'lucide:box'} fallback="box" size={20} /></span>
+```
+
+(Keep the rest of the card markup unchanged — the `svc-title`, `row-actions`, etc.)
+
+- [ ] **Step 3: Add styles**
+
+In the Settings `<style>`, add:
+
+```css
+  .svc-card[draggable='true'] { cursor: default; }
+  .svc-card.dragging { opacity: 0.5; }
+  .drag-handle {
+    cursor: grab;
+    color: var(--ink-faint);
+    font-size: 18px;
+    line-height: 1;
+    user-select: none;
+    padding-right: 2px;
+  }
+  .drag-handle:active { cursor: grabbing; }
+```
+
+- [ ] **Step 4: Build to typecheck**
+
+Run: `bun run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Manual smoke**
+
+`bun run dev` + `cd src/web && bun run dev`. Open Manage Services, drag a card to a new position, reload — order persists. Open the dashboard — card order matches.
+
+- [ ] **Step 6: Final full check**
+
+Run: `bun test && bun run build`
+Expected: server tests PASS, build clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/src/Settings.svelte
+git commit -m "feat(web): drag-and-drop reordering on Manage Services"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Single masonry flow, render from integrations → Task 5 (App). ✓
+- `position` column + ordering + reorder helper → Task 1. ✓
+- Reorder endpoint → Task 3; drag UI → Task 6. ✓
+- Display options as registry config fields → Task 2; consumed in render → Task 5 (WidgetHost). ✓
+- Schema shrink to `{title,theme}`, delete widget/column/page → Task 2. ✓
+- One-time migration preserving order + options → Task 4. ✓
+- Backup/restore carries position → Task 1 (`replaceAllIntegrations`) + Task 3 (`RestoreSchema`). ✓
+- Header page tabs + monitorIds from pages → Task 5 (Header). ✓
+- Web types drop Widget/Column/Page → Task 5. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. `NOTE` blocks point to concrete caller checks (`createIntegration` param type, `grep .pages`), not deferrals.
+
+**Type consistency:** `IntegrationRow.position` added in Task 1 (server) and Task 5 (web), used by `reorderIntegrations`, `replaceAllIntegrations`, App sort, restore schema. `WidgetHost` prop `{ integration: IntegrationRow }` matches App's `{integration}`. `createIntegration` param becomes `Omit<IntegrationRow,'id'|'position'>` — Task 1 NOTE confirms `app.ts` and migration callers don't pass those. `migrate-layout` uses `updateIntegration(id, {...row, config})` — `updateIntegration` keeps `Omit<IntegrationRow,'id'>` and ignores position (preserved). Registry `max`/`variant`/`style` field keys match WidgetHost's `c.max`/`c.variant`/`c.style` reads.
+
+**Known ordering note:** Task 5 removes `config.pages` usage; Tasks 1-4 (backend) must land first so the shrunk schema + integrations data are ready, but each task's own tests pass independently. Frontend build (Task 5) is the first point the whole app renders the new way.

--- a/docs/superpowers/specs/2026-06-26-import-export-bookmarks-design.md
+++ b/docs/superpowers/specs/2026-06-26-import-export-bookmarks-design.md
@@ -1,0 +1,157 @@
+# Import/Export + Bookmarks — Design
+
+Date: 2026-06-26
+Status: Approved (pre-implementation)
+
+## Goal
+
+Add two adoption-driving features to Labby:
+
+1. **Import/Export** — a full backup/restore of the entire configuration (dashboard layout + service integrations, including credentials).
+2. **Bookmarks** — a static link-tile widget (an app launcher), the "front door" use case every competing dashboard has and Labby lacks.
+
+The two pair naturally: there is currently no in-app layout editor, so export→edit→import is the practical way to hand-edit the dashboard JSON, and bookmarks are placed that way.
+
+## Context (current state)
+
+- **Two data stores:**
+  - `settings(key, value)` table — the `dashboard` key holds the whole dashboard JSON (title, theme, pages → columns → widgets).
+  - `integrations(id, name, type, config, enabled, refresh_seconds)` table — service connections. **Secrets live in `config`** (API keys, passwords).
+- Widgets reference an integration by `integrationId` (number). Every existing widget type requires an integration.
+- **No layout-editor UI and no dashboard-write endpoint exist** — the dashboard JSON is edited by hand in the DB today.
+- Integration types are driven by a registry map (`src/server/integrations/registry.ts`): each type is `{ label, defaultRefreshSeconds, fields, fetch(config), actions? }`. The Settings page ("Manage Services") renders a CRUD form from `integrationTypes()` meta, with a repeatable list-field editor already used for monitor `sites` and calendar `calendars`.
+- Widgets render via a `WidgetHost.svelte` `{#if widget.type === …}` switch. Live data normally arrives over SSE channels driven by the scheduler.
+- `Icon.svelte` / `resolveIconSrc` render any `http(s)://` or `/path` icon string as an `<img>`. `data:` URIs are NOT currently handled (only `di:`, `sh:`, `http(s)://`, `/path`, `lucide:`).
+
+## Decisions (locked)
+
+- Export = **full backup** (dashboard + integrations **with secrets**). Single export, with a plaintext-credentials warning in the UI.
+- Import = **full replace / restore**, behind a confirm dialog. Integration IDs preserved so widget references stay valid.
+- Bookmarks = **integration type + one-time fetch** (approach A). Reuses the existing integrations CRUD form as the "dedicated editor."
+- Favicon auto-fetch on add; **store the resolved favicon URL** (string), not a data URI.
+
+---
+
+## 1. Schema change (`src/server/config/schema.ts`)
+
+Add one variant to `WidgetSchema` (the discriminated union):
+
+```ts
+z.object({
+  type: z.literal('bookmarks'),
+  title: z.string(),
+  integrationId,
+}),
+```
+
+Keep the duplicated web-side type (`src/web/src/lib/stores.ts` / types) in sync. No other schema change — links live in the integration `config`, not the widget.
+
+## 2. Import / Export
+
+### Export — `GET /api/backup`
+
+Returns:
+
+```jsonc
+{
+  "version": 1,
+  "exportedAt": "<ISO timestamp>",
+  "dashboard": { /* parsed dashboard JSON */ },
+  "integrations": [ /* listIntegrations(), incl. secrets */ ]
+}
+```
+
+Response sets `Content-Disposition: attachment; filename="labby-backup-<YYYY-MM-DD>.json"`. Browser downloads it.
+
+### Restore — `POST /api/restore`
+
+1. Parse + validate the envelope with a Zod schema (`version === 1`, `dashboard` matches `DashboardSchema`, `integrations` matches the integration-row shape).
+2. On validation failure → `400` with the error message; DB untouched.
+3. On success, in a single `db.transaction(() => …)`:
+   - `replaceAllIntegrations(rows)` — wipe `integrations`, bulk-insert each row with its explicit `id`.
+   - `setSetting('dashboard', JSON.stringify(dashboard, null, 2))`.
+4. After the transaction: `reloadConfig()` (re-reads config, notifies listeners → scheduler restarts timers).
+
+### db.ts helper
+
+```ts
+export function replaceAllIntegrations(rows: IntegrationRow[]): void
+```
+
+Runs inside the caller's transaction: `DELETE FROM integrations;` then `INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds) VALUES (…)` for each row (explicit `id`).
+
+### UI (`Settings.svelte`, "Manage Services" header)
+
+- **Export backup** button → `window.location = '/api/backup'` (triggers download). Adjacent ⚠️ note: "Backup contains plaintext credentials — store it securely."
+- **Import backup** button → hidden `<input type="file" accept="application/json">`. On file pick → confirm dialog: *"This replaces all services and your dashboard layout with the backup's contents. Continue?"* → `POST /api/restore` → on success reload the page (or re-fetch integrations + dashboard); on error show the message.
+
+## 3. Bookmarks widget
+
+### Registry (`src/server/integrations/registry.ts`)
+
+New entry:
+
+```ts
+bookmarks: {
+  label: 'Bookmarks',
+  // no defaultRefreshSeconds → not scheduled, no SSE channel
+  fields: [{ key: 'links', label: 'Links', kind: 'list' }],
+  fetch: (c) => ({ links: (c.links as Link[]) ?? [] }),
+  // no actions
+},
+```
+
+- **Link shape:** `{ title: string; url: string; icon?: string }`.
+- No channel is added to the scheduler; bookmarks data is never polled.
+
+### Rendering
+
+- **`Bookmarks.svelte`** — on mount, `GET /api/integrations/:id/data` once; render a responsive tile grid (icon + title), each tile an `<a href target="_blank" rel="noopener">`. Implements loading / error / empty / ready states and respects reduced-motion, consistent with other widgets. Uses `Icon.svelte` for each link's icon (falls back to a lucide glyph when `icon` is empty/unreachable).
+- **`WidgetHost.svelte`** — add `{:else if widget.type === 'bookmarks'}` → `<Bookmarks …/>`.
+
+### Editor (`Settings.svelte`)
+
+Add a `links` list editor for the bookmarks type, mirroring the existing `addSite`/`removeSite` pattern: rows of `title`, `url`, `icon` (with favicon preview, see §4). The integrations CRUD form, type picker, save, and delete are reused as-is.
+
+## 4. Favicon auto-fetch
+
+### Endpoint — `GET /api/favicon?url=<url>`
+
+1. Validate `url` is a syntactically valid `http(s)` URL → else `{ icon: null }`.
+2. Fetch the page HTML using the `http.ts` `soft` wrapper (timeout, errors → soft null).
+3. Regex-scan for a `<link rel="…icon…" href="…">` (matches `icon`, `shortcut icon`, `apple-touch-icon`); resolve the `href` to an absolute URL against the page URL.
+4. Fallback: `<origin>/favicon.ico`.
+5. Return `{ icon: <absolute url> | null }`.
+
+```
+// ponytail: regex parse, not a full HTML parser — swap in a parser if it misses real-world sites
+```
+
+### Frontend
+
+In the links editor, on a link's `url` blur, if its `icon` field is empty, call `/api/favicon?url=…` and populate `icon` with the returned URL. The field stays editable and clearable. Stored value is the URL string → rendered by `Icon.svelte` unchanged.
+
+**Note:** works for LAN/internal hosts because the *server* fetches the favicon (same reachability as monitoring). Storing the URL (not a data URI) means the browser later loads it directly — fine on LAN/VPN. Data-URI durability is a possible future enhancement (would require a `data:` branch in `resolveIconSrc`).
+
+## 5. Testing
+
+- **`backup.test.ts`** — export envelope shape; restore round-trip preserves integration ids + dashboard; malformed payload → 400 and DB unchanged (rollback).
+- **`registry.test.ts`** — bookmarks `fetch` returns `{ links }` from config (incl. empty default).
+- **`favicon.test.ts`** — mocked `fetch`: parses `<link rel=icon>`; falls back to `/favicon.ico`; returns `{ icon: null }` on fetch failure / invalid URL.
+
+## Out of scope
+
+- Drag-and-drop / visual layout editor (separate, larger feature). Bookmarks placement uses the dashboard JSON, now editable via export→edit→import.
+- Selective / partial import, merge mode, encrypted backups, data-URI favicon storage.
+
+## Affected files
+
+- `src/server/config/schema.ts` — bookmarks widget variant.
+- `src/server/db.ts` — `replaceAllIntegrations`.
+- `src/server/integrations/registry.ts` — bookmarks type.
+- `src/server/integrations/favicon.ts` (new) — favicon resolver, + `favicon.test.ts`.
+- `src/server/app.ts` — `/api/backup`, `/api/restore`, `/api/favicon` routes; + `backup.test.ts`.
+- `src/web/src/components/WidgetHost.svelte` — bookmarks branch.
+- `src/web/src/components/Bookmarks.svelte` (new) — tile grid.
+- `src/web/src/Settings.svelte` — export/import buttons + links editor + favicon call.
+- `src/web/src/lib/stores.ts` (+ web types) — keep widget type in sync.

--- a/docs/superpowers/specs/2026-06-26-integration-driven-layout-design.md
+++ b/docs/superpowers/specs/2026-06-26-integration-driven-layout-design.md
@@ -1,0 +1,150 @@
+# Integration-Driven Layout — Design
+
+Date: 2026-06-26
+Status: Approved (pre-implementation)
+
+## Goal
+
+Remove Labby's separate, hand-edited dashboard layout (pages → columns → widgets JSON). The configuration page (Manage Services) becomes the single source of the dashboard: **every enabled integration renders as its widget, in `position` order.** Adding an integration adds a card; reordering on the config page reorders the board. This eliminates the "create integration → manually place widget in JSON" gap (the reason a bookmarks integration never appeared on the dashboard).
+
+## Decisions (locked)
+
+- **Single masonry flow.** Drop pages and columns entirely. Every integration is a card auto-flowed into the responsive masonry grid (what the default theme already does — it flattens columns today). Order = config order.
+- **Drag-and-drop reordering** on the config page, using **native HTML5 drag-and-drop** (no new dependency), with a drag handle. Order persists in a new `position` column.
+- **Display options move into integration config.** Per-widget options that lived in the layout JSON (monitor `variant`/`style`; `max` on feeds, *arr, calendar, downloads, beszel; beszel `systems`) become fields on the integration form, stored in the integration's `config` JSON.
+- **Multi-page goes away** (single board).
+- **A one-time migration preserves the user's current board** (order + per-widget options) instead of resetting it.
+
+## Current architecture (context)
+
+- Dashboard JSON in `settings.dashboard`: `{ title, theme, pages:[{name, columns:[{size, widgets:[{type, integrationId, ...opts}]}]}] }`.
+- `integrations` table: `{ id, name, type, config(JSON), enabled, refresh_seconds }`. Secrets live in `config`.
+- `App.svelte` renders pages→columns→widgets; for each widget it looks up the integration by `widget.integrationId` and passes `integrationType` to `WidgetHost`.
+- `WidgetHost.svelte` maps `widget.type` → component, passing props (`integrationId`, `max`, monitor `variant`/`style`, downloads `client` derived from integration type, *arr `kind`).
+- Widget data arrives via `getStore(integrationId)` + SSE `int:${id}` (per-integration; unchanged by this work).
+- `type`-name relationships that the new mapping must preserve:
+  - integration `qbittorrent` / `transmission` → **Downloads** component, `client` = the integration type.
+  - integration `radarr` / `sonarr` → **Arr** component, `kind` = the integration type.
+  - integration `reddit` / `hackernews` → **Feed** component (different icon/fallback per type).
+  - integration `monitor` → **Monitor** component, `variant` (rows/tiles) + `style` from config.
+  - all others → their 1:1 component.
+- Theme/title stay relevant: `Header` shows `config.title`; theme drives first-paint.
+
+## 1. Data model
+
+- **`integrations.position`** — new `INTEGER` column (migration). `listIntegrations()` returns rows ordered by `position ASC, id ASC`. New integrations get `position` = current max + 1 (or `id` fallback).
+- **Display options live in `config`** (no new columns). Fields added to the registry (see §3) so the form reads/writes them automatically.
+- **`dashboard` settings row → `{ title, theme }`.** `pages` removed.
+
+## 2. Schema (`src/server/config/schema.ts`)
+
+- `DashboardSchema` becomes:
+  ```ts
+  export const DashboardSchema = z.object({
+    title: z.string().default('Labby'),
+    theme: ThemeConfigSchema.default({ default: 'system', layout: 'masonry' }),
+  });
+  ```
+- **Delete** `WidgetSchema`, `ColumnSchema`, `PageSchema`, the `Widget` type export, and `SiteSchema` usage that only fed widgets (keep `SiteSchema` — monitor config still uses sites). `sanitizeDashboard` stays (deep clone of `{title,theme}`).
+- `ThemeConfigSchema.layout` (masonry/columns) is now vestigial — keep the field for back-compat parsing but the UI always renders masonry. (Leaving it avoids breaking older stored theme blobs.)
+
+## 3. Registry (`src/server/integrations/registry.ts`)
+
+Add display-option fields to the relevant types' `fields` arrays (kind `number` or `select`), so the existing Settings form renders them and stores them in `config`:
+
+- `monitor`: `{ key:'variant', label:'Display', kind:'select', options:['rows','tiles'] }`, `{ key:'style', label:'Density', kind:'select', options:['default','compact'] }`
+- `qbittorrent`, `transmission`: `{ key:'max', label:'Max items', kind:'number' }`
+- `beszel`: `{ key:'max', label:'Max systems', kind:'number' }` (keep existing `systems` handling if present in config)
+- `radarr`, `sonarr`, `reelward`: `{ key:'max', label:'Max items', kind:'number' }`
+- `reddit`, `hackernews`: `{ key:'max', label:'Max items', kind:'number' }`
+- `calendar`: `{ key:'max', label:'Max events', kind:'number' }`
+
+`fetch` functions are unchanged (they already accept the full config; `max` is a display concern read on the client, so the server need not use it — the widget components slice by `max`).
+
+## 4. DB (`src/server/db.ts`)
+
+- Migration: `ALTER TABLE integrations ADD COLUMN position INTEGER;` then backfill `position = id` for existing rows.
+- `IntegrationRow` gains `position: number`. `toRow` maps it; `createIntegration` sets `position` = `(SELECT COALESCE(MAX(position),0)+1 FROM integrations)`; `listIntegrations` `ORDER BY position, id`.
+- New: `reorderIntegrations(orderedIds: number[]): void` — in one transaction, set `position` = array index for each id.
+- `replaceAllIntegrations` (restore) must insert `position` too.
+
+## 5. Server routes (`src/server/app.ts`)
+
+- `POST /api/integrations/reorder` — body `{ ids: number[] }`, validated with Zod, calls `reorderIntegrations`, then `startScheduler()` is **not** needed (order doesn't affect polling), returns `{ ok: true }`.
+- Backup/restore: `RestoreSchema.dashboard` becomes the new `{title, theme}` shape; `integrations` row shape gains `position`. Export already serializes whatever `listIntegrations()` returns (now includes `position`).
+
+## 6. One-time data migration (preserve current board)
+
+A run-once migration (guarded by a `settings` flag `layout_migrated=1`, or a numbered migration that runs JS):
+
+1. Read the existing `dashboard` JSON. If it has `pages`:
+2. Walk `pages[].columns[].widgets[]` in order. For each widget, by `integrationId`:
+   - merge the widget's display options (`max`, `variant`, `style`, `systems`) into that integration's `config` (don't overwrite existing config keys that aren't display options).
+   - assign the integration's `position` from a running counter following the widget walk order.
+3. Integrations not referenced by any widget keep `position = id` (appended after).
+4. Rewrite `dashboard` to `{ title, theme }`.
+5. Set the `layout_migrated` flag.
+
+This runs on the user's live instance so their current order + options survive.
+
+## 7. Frontend
+
+### `App.svelte`
+- Remove page tabs, `activePageIndex`, columns/masonry branch on `theme.layout`.
+- Fetch enabled integrations (ordered) — reuse the existing `/api/integrations` fetch — filter `enabled`, sort by `position`.
+- Render a single masonry `.grid` of `<WidgetHost {integration} />` for each.
+- Keep `initStream()` (SSE) and the `integrationsById` map source-of-truth, now also the render list.
+
+### `WidgetHost.svelte`
+- Props change from `{ widget, integrationType }` to `{ integration }` where `integration = { id, type, name, config }`.
+- Switch on `integration.type`; derive props:
+  - title = `integration.name`
+  - `integrationId` = `integration.id`
+  - `monitor`: `variant = config.variant ?? 'rows'`, `style = config.style`
+  - `qbittorrent`/`transmission`: `<Downloads client={integration.type} max={config.max} />`
+  - `radarr`/`sonarr`: `<Arr kind={integration.type} max={config.max} />`
+  - `reddit`/`hackernews`: `<Feed icon=… max={config.max} />`
+  - `bookmarks`: `<Bookmarks />` (its links come from config via the integration store)
+  - others: 1:1 component with `max` where applicable.
+
+### `Settings.svelte`
+- Service cards become reorderable via native HTML5 DnD: each card gets `draggable`, a drag handle, and `dragstart`/`dragover`/`drop` handlers that compute the new order and call `POST /api/integrations/reorder`, then reload the list. Provide a visible focus state on the handle; keyboard reordering is out of scope for v1 (documented limitation).
+- Display-option fields render automatically (they're registry fields now). No bespoke per-field UI needed beyond the existing `select`/`number` handling.
+- The export/import backup section (added previously) stays at the page footer.
+
+### `Header.svelte`
+- Remove page tabs (no `pages`). Title display unchanged.
+
+## 8. Types (web)
+
+- `src/web/src/lib/types.ts`: remove `Widget`, `Column`, `Page`; `Dashboard` becomes `{ title, theme }`. `IntegrationRow` gains `position: number`.
+- Keep server/web duplication in sync.
+
+## 9. Testing
+
+- `schema.test.ts`: `{title, theme}` parses; a payload with `pages` still parses (pages ignored) — no throw.
+- `db.integrations.test.ts`: `position` round-trips; `createIntegration` assigns increasing positions; `reorderIntegrations([...])` persists the given order; `listIntegrations` returns position order.
+- `registry.test.ts`: monitor has `variant`+`style` fields; feeds/*arr/calendar/downloads/beszel have a `max` field. (Bump any field-count assertions.)
+- `app` test: `POST /api/integrations/reorder` reorders; backup round-trips `position` + config display options.
+- Migration test: given an old `dashboard` JSON with widgets carrying `max`/`variant` and a custom order, the migration merges options into the matching integrations' config and assigns positions in widget order; `dashboard` is rewritten to `{title,theme}`.
+
+## Out of scope
+
+- Multi-page dashboards (removed).
+- Keyboard-accessible drag reordering (up/down arrows could be a later a11y addition).
+- A separate visual canvas/grid editor (the config list *is* the editor).
+- Per-integration width/spanning (single masonry sizing only).
+
+## Affected files
+
+- `src/server/config/schema.ts` — shrink `DashboardSchema`, delete widget/column/page schemas.
+- `src/server/config/loader.ts` — validate new shape (likely no change beyond schema).
+- `src/server/db.ts` — `position` column + migration, `reorderIntegrations`, `IntegrationRow.position`, create/list/replace updates, one-time data migration.
+- `src/server/integrations/registry.ts` — display-option fields.
+- `src/server/app.ts` — `/api/integrations/reorder`, restore schema update.
+- `src/web/src/App.svelte` — integration-driven render, drop pages/columns.
+- `src/web/src/components/WidgetHost.svelte` — integration-keyed mapping.
+- `src/web/src/components/Header.svelte` — drop page tabs.
+- `src/web/src/Settings.svelte` — drag reorder + reorder call.
+- `src/web/src/lib/types.ts` — drop Widget/Column/Page, `Dashboard` shrink, `IntegrationRow.position`.
+- Tests alongside each.

--- a/src/server/app.integrations.test.ts
+++ b/src/server/app.integrations.test.ts
@@ -14,7 +14,7 @@ test('GET /api/integrations/types returns metadata without fetch', async () => {
   const res = await app.request('/api/integrations/types');
   expect(res.status).toBe(200);
   const body = (await res.json()) as any[];
-  expect(body.length).toBe(15);
+  expect(body.length).toBe(16);
   for (const item of body) {
     expect(item).toHaveProperty('type');
     expect(item).toHaveProperty('label');

--- a/src/server/app.reorder.test.ts
+++ b/src/server/app.reorder.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { app } from './app';
+import { createIntegration, deleteIntegration, listIntegrations } from './db';
+
+test('POST /api/integrations/reorder sets the given order', async () => {
+  const tag = '__reorder_api__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
+  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  try {
+    const res = await app.request('/api/integrations/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [b.id, a.id] }),
+    });
+    expect(res.status).toBe(200);
+    const ordered = listIntegrations().filter((r) => r.name.startsWith(tag));
+    expect(ordered[0].id).toBe(b.id);
+  } finally {
+    deleteIntegration(a.id);
+    deleteIntegration(b.id);
+  }
+});
+
+test('POST /api/integrations/reorder rejects a non-array body with 400', async () => {
+  const res = await app.request('/api/integrations/reorder', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids: 'nope' }),
+  });
+  expect(res.status).toBe(400);
+});

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -303,6 +303,7 @@ app.post('/api/restore', async (c) => {
   replaceAllIntegrations(integrations);
   setSetting('dashboard', JSON.stringify(dashboard, null, 2));
   reloadConfig();
+  startScheduler();
   return c.json({ ok: true });
 });
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -7,6 +7,7 @@ import { getConfig, getConfigState, reloadConfig, saveThemeSettings } from './co
 import { DashboardSchema, DensitySchema, LayoutSchema, sanitizeDashboard, ThemeSchema } from './config/schema';
 import {
   createIntegration,
+  db,
   deleteIntegration,
   getIntegration,
   getSetting,
@@ -272,29 +273,35 @@ app.get('/api/backup', (c) => {
       dashboard = null; // corrupt row — export best-effort rather than 500
     }
   }
+  const exportedAt = new Date().toISOString();
   const body = {
     version: 1 as const,
-    exportedAt: new Date().toISOString(),
+    exportedAt,
     dashboard,
     integrations: listIntegrations(),
   };
   c.header('Content-Type', 'application/json');
   c.header(
     'Content-Disposition',
-    `attachment; filename="labby-backup-${new Date().toISOString().slice(0, 10)}.json"`,
+    `attachment; filename="labby-backup-${exportedAt.slice(0, 10)}.json"`,
   );
   return c.body(JSON.stringify(body, null, 2));
 });
 
+const INTEGRATION_TYPES = Object.keys(INTEGRATIONS) as [IntegrationType, ...IntegrationType[]];
+
 const RestoreSchema = z.object({
   version: z.literal(1),
   exportedAt: z.string().optional(),
-  dashboard: DashboardSchema,
+  // Export emits null when the dashboard row is missing/corrupt; accept it back.
+  dashboard: DashboardSchema.nullable(),
   integrations: z.array(
     z.object({
       id: z.number().int(),
       name: z.string(),
-      type: z.string(),
+      // Reject unknown types so a corrupt/hand-edited backup can't write rows
+      // the scheduler and UI will silently drop.
+      type: z.enum(INTEGRATION_TYPES),
       config: z.record(z.unknown()),
       enabled: z.boolean(),
       refreshSeconds: z.number().int().nullable(),
@@ -310,9 +317,13 @@ app.post('/api/restore', async (c) => {
     return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid backup file' }, 400);
   }
   const { dashboard, integrations } = parsed.data;
-  replaceAllIntegrations(integrations);
-  setSetting('dashboard', JSON.stringify(dashboard, null, 2));
-  reloadConfig();
+  // Atomic: integrations + dashboard land together or not at all, so a crash
+  // mid-restore can't leave a half-applied (split-brain) state.
+  db.transaction(() => {
+    replaceAllIntegrations(integrations);
+    if (dashboard) setSetting('dashboard', JSON.stringify(dashboard, null, 2));
+  })();
+  await reloadConfig();
   startScheduler();
   return c.json({ ok: true });
 });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2,13 +2,17 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { type Context, Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
-import { getConfig, getConfigState, saveThemeSettings } from './config/loader';
-import { DensitySchema, LayoutSchema, sanitizeDashboard, ThemeSchema } from './config/schema';
+import { z } from 'zod';
+import { getConfig, getConfigState, reloadConfig, saveThemeSettings } from './config/loader';
+import { DashboardSchema, DensitySchema, LayoutSchema, sanitizeDashboard, ThemeSchema } from './config/schema';
 import {
   createIntegration,
   deleteIntegration,
   getIntegration,
+  getSetting,
   listIntegrations,
+  replaceAllIntegrations,
+  setSetting,
   updateIntegration,
 } from './db';
 import { containerLogs, type DockerConfig } from './integrations/docker-client';
@@ -247,6 +251,53 @@ app.get('/icons/*', serveStatic);
 app.get('/fonts/*', serveStatic);
 app.get('/manifest.webmanifest', serveStatic);
 app.get('/sw.js', serveStatic);
+
+// --- backup / restore ---
+app.get('/api/backup', (c) => {
+  const dashboardRaw = getSetting('dashboard');
+  const dashboard = dashboardRaw ? JSON.parse(dashboardRaw) : null;
+  const body = {
+    version: 1 as const,
+    exportedAt: new Date().toISOString(),
+    dashboard,
+    integrations: listIntegrations(),
+  };
+  c.header('Content-Type', 'application/json');
+  c.header(
+    'Content-Disposition',
+    `attachment; filename="labby-backup-${new Date().toISOString().slice(0, 10)}.json"`,
+  );
+  return c.body(JSON.stringify(body, null, 2));
+});
+
+const RestoreSchema = z.object({
+  version: z.literal(1),
+  exportedAt: z.string().optional(),
+  dashboard: DashboardSchema,
+  integrations: z.array(
+    z.object({
+      id: z.number().int(),
+      name: z.string(),
+      type: z.string(),
+      config: z.record(z.unknown()),
+      enabled: z.boolean(),
+      refreshSeconds: z.number().int().nullable(),
+    }),
+  ),
+});
+
+app.post('/api/restore', async (c) => {
+  const json = await c.req.json().catch(() => null);
+  const parsed = RestoreSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid backup file' }, 400);
+  }
+  const { dashboard, integrations } = parsed.data;
+  replaceAllIntegrations(integrations);
+  setSetting('dashboard', JSON.stringify(dashboard, null, 2));
+  reloadConfig();
+  return c.json({ ok: true });
+});
 
 app.get('*', async (c) => {
   const html = await readFile(INDEX_PATH, 'utf-8').catch(() => null);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,6 +12,7 @@ import {
   updateIntegration,
 } from './db';
 import { containerLogs, type DockerConfig } from './integrations/docker-client';
+import { resolveFavicon } from './integrations/favicon';
 import { getJellyfinImage, type JellyfinConfig } from './integrations/jellyfin';
 import { INTEGRATIONS, type IntegrationType, integrationTypes } from './integrations/registry';
 import { hub } from './sse/hub';
@@ -58,6 +59,12 @@ app.get('/api/config', (c) => {
   const state = getConfigState();
   if (!state.ok) return c.json({ error: state.error }, 500);
   return c.json(sanitizeDashboard(state.config));
+});
+
+app.get('/api/favicon', async (c) => {
+  const url = c.req.query('url');
+  if (!url) return c.json({ icon: null });
+  return c.json(await resolveFavicon(url));
 });
 
 app.get('/api/integrations/types', (c) => c.json(integrationTypes()));

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,6 +12,7 @@ import {
   getSetting,
   listIntegrations,
   replaceAllIntegrations,
+  reorderIntegrations,
   setSetting,
   updateIntegration,
 } from './db';
@@ -107,6 +108,14 @@ app.put('/api/integrations/:id', async (c) => {
 app.delete('/api/integrations/:id', (c) => {
   deleteIntegration(Number(c.req.param('id')));
   startScheduler();
+  return c.json({ ok: true });
+});
+
+app.post('/api/integrations/reorder', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = z.object({ ids: z.array(z.number().int()) }).safeParse(body);
+  if (!parsed.success) return c.json({ error: 'Invalid reorder payload' }, 400);
+  reorderIntegrations(parsed.data.ids);
   return c.json({ ok: true });
 });
 
@@ -289,6 +298,7 @@ const RestoreSchema = z.object({
       config: z.record(z.unknown()),
       enabled: z.boolean(),
       refreshSeconds: z.number().int().nullable(),
+      position: z.number().int().optional(),
     }),
   ),
 });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -255,7 +255,14 @@ app.get('/sw.js', serveStatic);
 // --- backup / restore ---
 app.get('/api/backup', (c) => {
   const dashboardRaw = getSetting('dashboard');
-  const dashboard = dashboardRaw ? JSON.parse(dashboardRaw) : null;
+  let dashboard: unknown = null;
+  if (dashboardRaw) {
+    try {
+      dashboard = JSON.parse(dashboardRaw);
+    } catch {
+      dashboard = null; // corrupt row — export best-effort rather than 500
+    }
+  }
   const body = {
     version: 1 as const,
     exportedAt: new Date().toISOString(),

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -44,7 +44,7 @@ test('POST /api/restore rejects a malformed payload with 400 and leaves the DB i
   const res = await app.request('/api/restore', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ version: 1, dashboard: { nope: true }, integrations: [] }),
+    body: JSON.stringify({ version: 1, dashboard: { title: 'x', theme: { default: 'not-a-valid-theme' } }, integrations: [] }),
   });
   expect(res.status).toBe(400);
   expect(listIntegrations().length).toBe(before);

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'bun:test';
+import { createIntegration, deleteIntegration, listIntegrations, replaceAllIntegrations } from './db';
+import { app } from './app';
+
+const TAG = '__test_backup__';
+
+function cleanup() {
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(TAG))) deleteIntegration(r.id);
+}
+
+test('replaceAllIntegrations wipes then restores rows preserving ids', () => {
+  cleanup();
+  // snapshot current rows so we can restore the DB after the test
+  const original = listIntegrations();
+  try {
+    const restored = [
+      { id: 9001, name: `${TAG}a`, type: 'radarr', config: { url: 'http://a' }, enabled: true, refreshSeconds: 60 },
+      { id: 9002, name: `${TAG}b`, type: 'sonarr', config: {}, enabled: false, refreshSeconds: null },
+    ];
+    replaceAllIntegrations(restored);
+    const after = listIntegrations();
+    expect(after.length).toBe(2);
+    expect(after.find((r) => r.id === 9001)?.name).toBe(`${TAG}a`);
+    expect(after.find((r) => r.id === 9001)?.config).toEqual({ url: 'http://a' });
+    expect(after.find((r) => r.id === 9002)?.enabled).toBe(false);
+  } finally {
+    // restore the original integrations table
+    replaceAllIntegrations(original);
+  }
+});
+
+test('GET /api/backup returns version, dashboard, and integrations', async () => {
+  const res = await app.request('/api/backup');
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as any;
+  expect(body.version).toBe(1);
+  expect(body.dashboard).toBeDefined();
+  expect(Array.isArray(body.integrations)).toBe(true);
+});
+
+test('POST /api/restore rejects a malformed payload with 400 and leaves the DB intact', async () => {
+  const before = listIntegrations().length;
+  const res = await app.request('/api/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ version: 1, dashboard: { nope: true }, integrations: [] }),
+  });
+  expect(res.status).toBe(400);
+  expect(listIntegrations().length).toBe(before);
+});
+
+test('POST /api/restore round-trips a valid backup', async () => {
+  const original = await (await app.request('/api/backup')).json();
+  try {
+    const res = await app.request('/api/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(original),
+    });
+    expect(res.status).toBe(200);
+    const again = await (await app.request('/api/backup')).json();
+    expect(again.integrations.length).toBe(original.integrations.length);
+  } finally {
+    // ensure DB returns to the original snapshot regardless
+    await app.request('/api/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(original),
+    });
+  }
+});

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -36,6 +36,7 @@ test('GET /api/backup returns version, dashboard, and integrations', async () =>
   expect(body.version).toBe(1);
   expect(body.dashboard).toBeDefined();
   expect(Array.isArray(body.integrations)).toBe(true);
+  expect(res.headers.get('Content-Disposition')).toMatch(/attachment; filename="labby-backup-/);
 });
 
 test('POST /api/restore rejects a malformed payload with 400 and leaves the DB intact', async () => {

--- a/src/server/config/loader.test.ts
+++ b/src/server/config/loader.test.ts
@@ -35,7 +35,7 @@ describe('config loader', () => {
   });
 
   test('loadConfig returns error for schema violation', async () => {
-    setSetting('dashboard', JSON.stringify({ title: 'x', pages: [] }));
+    setSetting('dashboard', JSON.stringify({ title: 'x', theme: { default: 'not-a-valid-theme' } }));
     const result = await loadConfig();
     expect(result.ok).toBe(false);
   });

--- a/src/server/config/loader.ts
+++ b/src/server/config/loader.ts
@@ -75,6 +75,6 @@ export async function saveThemeSettings(settings: {
   setState({ ok: true, config });
 }
 
-export function reloadConfig(): void {
-  void loadConfig();
+export function reloadConfig(): Promise<ConfigState> {
+  return loadConfig();
 }

--- a/src/server/config/migrate-layout.test.ts
+++ b/src/server/config/migrate-layout.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test';
+import { createIntegration, deleteIntegration, getIntegration, getSetting, listIntegrations, setSetting, deleteSetting } from '../db';
+import { migrateLayoutToIntegrations } from './migrate-layout';
+
+test('migration folds widget options + order into integrations and rewrites dashboard', () => {
+  const tag = '__migrate__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const savedDash = getSetting('dashboard');
+  const savedFlag = getSetting('layout_migrated');
+  deleteSetting('layout_migrated');
+
+  const m = createIntegration({ name: `${tag}mon`, type: 'monitor', config: { sites: [] }, enabled: true, refreshSeconds: null });
+  const f = createIntegration({ name: `${tag}feed`, type: 'reddit', config: { subreddits: ['x'] }, enabled: true, refreshSeconds: null });
+
+  // legacy dashboard: feed first, monitor second; options on widgets
+  setSetting('dashboard', JSON.stringify({
+    title: 'My Board',
+    theme: { default: 'dark' },
+    pages: [{ name: 'Home', columns: [{ size: 'full', widgets: [
+      { type: 'reddit', integrationId: f.id, max: 9 },
+      { type: 'monitor', integrationId: m.id, variant: 'tiles', style: 'compact' },
+    ] }] }],
+  }));
+
+  try {
+    migrateLayoutToIntegrations();
+    // options merged into config
+    expect(getIntegration(f.id)?.config.max).toBe(9);
+    expect(getIntegration(m.id)?.config.variant).toBe('tiles');
+    expect(getIntegration(m.id)?.config.style).toBe('compact');
+    // order: feed (first widget) before monitor
+    expect(getIntegration(f.id)!.position).toBeLessThan(getIntegration(m.id)!.position);
+    // dashboard rewritten without pages, title/theme kept
+    const dash = JSON.parse(getSetting('dashboard') as string);
+    expect(dash.pages).toBeUndefined();
+    expect(dash.title).toBe('My Board');
+    expect(dash.theme.default).toBe('dark');
+    // idempotent: second run is a no-op (flag set)
+    expect(getSetting('layout_migrated')).toBe('1');
+  } finally {
+    deleteIntegration(m.id);
+    deleteIntegration(f.id);
+    if (savedDash !== null) setSetting('dashboard', savedDash);
+    if (savedFlag !== null) setSetting('layout_migrated', savedFlag); else deleteSetting('layout_migrated');
+  }
+});

--- a/src/server/config/migrate-layout.ts
+++ b/src/server/config/migrate-layout.ts
@@ -1,0 +1,54 @@
+import { getSetting, listIntegrations, reorderIntegrations, setSetting, updateIntegration } from '../db';
+
+const DISPLAY_KEYS = ['max', 'variant', 'style', 'systems'] as const;
+
+// One-time: fold the legacy pages/columns/widgets layout into the integrations
+// (display options -> config, widget order -> position), then rewrite the
+// dashboard row to just {title, theme}. Guarded by the `layout_migrated` flag.
+export function migrateLayoutToIntegrations(): void {
+  if (getSetting('layout_migrated') === '1') return;
+
+  const raw = getSetting('dashboard');
+  if (!raw) {
+    setSetting('layout_migrated', '1');
+    return;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    setSetting('layout_migrated', '1');
+    return;
+  }
+
+  if (Array.isArray(parsed?.pages)) {
+    const byId = new Map(listIntegrations().map((r) => [r.id, r]));
+    const orderedIds: number[] = [];
+
+    for (const page of parsed.pages) {
+      for (const col of page?.columns ?? []) {
+        for (const w of col?.widgets ?? []) {
+          const row = byId.get(w?.integrationId);
+          if (!row) continue;
+          if (!orderedIds.includes(row.id)) orderedIds.push(row.id);
+          const merged = { ...row.config };
+          for (const k of DISPLAY_KEYS) {
+            if (w[k] !== undefined && merged[k] === undefined) merged[k] = w[k];
+          }
+          updateIntegration(row.id, { ...row, config: merged });
+        }
+      }
+    }
+
+    // any integration not referenced by a widget keeps its place after the rest
+    for (const r of listIntegrations()) if (!orderedIds.includes(r.id)) orderedIds.push(r.id);
+    reorderIntegrations(orderedIds);
+  }
+
+  setSetting('dashboard', JSON.stringify({
+    title: parsed?.title ?? 'Labby',
+    theme: parsed?.theme ?? { default: 'system' },
+  }, null, 2));
+  setSetting('layout_migrated', '1');
+}

--- a/src/server/config/migrate-layout.ts
+++ b/src/server/config/migrate-layout.ts
@@ -1,4 +1,4 @@
-import { getSetting, listIntegrations, reorderIntegrations, setSetting, updateIntegration } from '../db';
+import { db, getSetting, listIntegrations, reorderIntegrations, setSetting, updateIntegration } from '../db';
 
 const DISPLAY_KEYS = ['max', 'variant', 'style', 'systems'] as const;
 
@@ -22,33 +22,38 @@ export function migrateLayoutToIntegrations(): void {
     return;
   }
 
-  if (Array.isArray(parsed?.pages)) {
-    const byId = new Map(listIntegrations().map((r) => [r.id, r]));
-    const orderedIds: number[] = [];
+  // One transaction: config merges, reorder, dashboard rewrite, and the
+  // `layout_migrated` flag commit together — a crash can't leave it half-applied
+  // and re-run on next boot (which would clobber positions / manual edits).
+  db.transaction(() => {
+    if (Array.isArray(parsed?.pages)) {
+      const byId = new Map(listIntegrations().map((r) => [r.id, r]));
+      const ordered = new Set<number>();
 
-    for (const page of parsed.pages) {
-      for (const col of page?.columns ?? []) {
-        for (const w of col?.widgets ?? []) {
-          const row = byId.get(w?.integrationId);
-          if (!row) continue;
-          if (!orderedIds.includes(row.id)) orderedIds.push(row.id);
-          const merged = { ...row.config };
-          for (const k of DISPLAY_KEYS) {
-            if (w[k] !== undefined && merged[k] === undefined) merged[k] = w[k];
+      for (const page of parsed.pages) {
+        for (const col of page?.columns ?? []) {
+          for (const w of col?.widgets ?? []) {
+            const row = byId.get(w?.integrationId);
+            if (!row) continue;
+            ordered.add(row.id);
+            const merged = { ...row.config };
+            for (const k of DISPLAY_KEYS) {
+              if (w[k] !== undefined && merged[k] === undefined) merged[k] = w[k];
+            }
+            updateIntegration(row.id, { ...row, config: merged });
           }
-          updateIntegration(row.id, { ...row, config: merged });
         }
       }
+
+      // any integration not referenced by a widget keeps its place after the rest
+      for (const r of byId.values()) ordered.add(r.id);
+      reorderIntegrations([...ordered]);
     }
 
-    // any integration not referenced by a widget keeps its place after the rest
-    for (const r of listIntegrations()) if (!orderedIds.includes(r.id)) orderedIds.push(r.id);
-    reorderIntegrations(orderedIds);
-  }
-
-  setSetting('dashboard', JSON.stringify({
-    title: parsed?.title ?? 'Labby',
-    theme: parsed?.theme ?? { default: 'system' },
-  }, null, 2));
-  setSetting('layout_migrated', '1');
+    setSetting('dashboard', JSON.stringify({
+      title: parsed?.title ?? 'Labby',
+      theme: parsed?.theme ?? { default: 'system' },
+    }, null, 2));
+    setSetting('layout_migrated', '1');
+  })();
 }

--- a/src/server/config/schema.test.ts
+++ b/src/server/config/schema.test.ts
@@ -2,40 +2,16 @@ import { describe, expect, test } from 'bun:test';
 import { DashboardSchema } from './schema';
 
 describe('DashboardSchema', () => {
-  test('parses minimal valid config', () => {
-    const config = DashboardSchema.parse({
-      title: 'Labby',
-      pages: [
-        {
-          name: 'Overview',
-          columns: [
-            {
-              size: 'small',
-              widgets: [
-                {
-                  type: 'monitor',
-                  title: 'Core',
-                  integrationId: 1,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+  test('parses minimal valid config with defaults', () => {
+    const config = DashboardSchema.parse({ title: 'Labby' });
     expect(config.title).toBe('Labby');
     expect(config.theme.default).toBe('system');
-  });
-
-  test('rejects empty pages', () => {
-    expect(() => DashboardSchema.parse({ title: 'x', pages: [] })).toThrow();
   });
 
   test('parses named color scheme', () => {
     const config = DashboardSchema.parse({
       title: 'Labby',
       theme: { default: 'dark-ocean' },
-      pages: [{ name: 'Overview', columns: [{ size: 'small', widgets: [] }] }],
     });
     expect(config.theme.default).toBe('dark-ocean');
   });
@@ -44,72 +20,19 @@ describe('DashboardSchema', () => {
     const config = DashboardSchema.parse({
       title: 'Labby',
       theme: { default: 'dark-ocean', layout: 'columns', density: 'compact' },
-      pages: [{ name: 'Overview', columns: [{ size: 'small', widgets: [] }] }],
     });
     expect(config.theme.default).toBe('dark-ocean');
     expect(config.theme.layout).toBe('columns');
     expect(config.theme.density).toBe('compact');
   });
 
-  test('parses weather widget with integrationId', () => {
-    const config = DashboardSchema.parse({
-      title: 'Labby',
-      pages: [
-        {
-          name: 'Overview',
-          columns: [
-            {
-              size: 'small',
-              widgets: [{ type: 'weather', title: 'Weather', integrationId: 2 }],
-            },
-          ],
-        },
-      ],
-    });
-    expect(config.pages[0].columns[0].widgets[0]).toMatchObject({
-      type: 'weather',
-      integrationId: 2,
-    });
+  test('DashboardSchema accepts {title, theme} without pages', () => {
+    const parsed = DashboardSchema.parse({ title: 'Home', theme: { default: 'dark' } });
+    expect(parsed.title).toBe('Home');
   });
 
-  test('parses media service widgets', () => {
-    const config = DashboardSchema.parse({
-      title: 'Labby',
-      pages: [
-        {
-          name: 'Overview',
-          columns: [
-            {
-              size: 'small',
-              widgets: [
-                { type: 'radarr', title: 'Radarr', integrationId: 3, max: 3 },
-                { type: 'sonarr', title: 'Sonarr', integrationId: 4, max: 3 },
-                { type: 'reelward', title: 'Reelward', integrationId: 5, max: 3 },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-    expect(config.pages[0].columns[0].widgets).toHaveLength(3);
-  });
-
-  test('rejects monitor widget without integrationId', () => {
-    expect(() =>
-      DashboardSchema.parse({
-        title: 'Labby',
-        pages: [
-          {
-            name: 'Overview',
-            columns: [
-              {
-                size: 'small',
-                widgets: [{ type: 'monitor', title: 'Core', sites: [] }],
-              },
-            ],
-          },
-        ],
-      }),
-    ).toThrow();
+  test('DashboardSchema ignores a legacy pages field', () => {
+    const parsed = DashboardSchema.parse({ title: 'X', theme: { default: 'system' }, pages: [{ junk: true }] });
+    expect((parsed as any).pages).toBeUndefined();
   });
 });

--- a/src/server/config/schema.ts
+++ b/src/server/config/schema.ts
@@ -49,116 +49,12 @@ export const SiteSchema = z.object({
   okCodes: z.array(z.number()).optional(),
 });
 
-const integrationId = z.number().int();
-
-export const WidgetSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('monitor'),
-    title: z.string(),
-    integrationId,
-    style: z.enum(['compact', 'default']).optional(),
-    variant: z.enum(['rows', 'tiles']).optional(),
-  }),
-  z.object({
-    type: z.literal('docker'),
-    title: z.string(),
-    integrationId,
-  }),
-  z.object({
-    type: z.literal('downloads'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('adguard'),
-    title: z.string(),
-    integrationId,
-  }),
-  z.object({
-    type: z.literal('jellyfin'),
-    title: z.string(),
-    integrationId,
-  }),
-  z.object({
-    type: z.literal('beszel'),
-    title: z.string(),
-    integrationId,
-    systems: z.array(z.string()).optional(),
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('radarr'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('sonarr'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('reelward'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('reddit'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('hackernews'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('weather'),
-    title: z.string(),
-    integrationId,
-  }),
-  z.object({
-    type: z.literal('calendar'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('speedtest'),
-    title: z.string(),
-    integrationId,
-    max: z.number().int().positive().optional(),
-  }),
-  z.object({
-    type: z.literal('bookmarks'),
-    title: z.string(),
-    integrationId,
-  }),
-]);
-
-export const ColumnSchema = z.object({
-  size: z.enum(['small', 'full']),
-  widgets: z.array(WidgetSchema),
-});
-
-export const PageSchema = z.object({
-  name: z.string(),
-  columns: z.array(ColumnSchema),
-});
-
 export const DashboardSchema = z.object({
   title: z.string().default('Labby'),
   theme: ThemeConfigSchema.default({ default: 'system', layout: 'masonry' }),
-  pages: z.array(PageSchema).min(1),
 });
 
 export type Dashboard = z.infer<typeof DashboardSchema>;
-export type Widget = z.infer<typeof WidgetSchema>;
 export type Site = z.infer<typeof SiteSchema>;
 
 export function sanitizeDashboard(config: Dashboard): Dashboard {

--- a/src/server/config/schema.ts
+++ b/src/server/config/schema.ts
@@ -134,6 +134,11 @@ export const WidgetSchema = z.discriminatedUnion('type', [
     integrationId,
     max: z.number().int().positive().optional(),
   }),
+  z.object({
+    type: z.literal('bookmarks'),
+    title: z.string(),
+    integrationId,
+  }),
 ]);
 
 export const ColumnSchema = z.object({

--- a/src/server/db.integrations.test.ts
+++ b/src/server/db.integrations.test.ts
@@ -4,6 +4,7 @@ import {
   deleteIntegration,
   getIntegration,
   listIntegrations,
+  reorderIntegrations,
   updateIntegration,
 } from './db';
 
@@ -30,4 +31,22 @@ test('integration CRUD round-trips config as JSON', () => {
     deleteIntegration(row.id);
   }
   expect(getIntegration(row.id)).toBeNull();
+});
+
+test('position is assigned on create and returned in order', () => {
+  const tag = '__pos_test__';
+  for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
+  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
+  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  try {
+    expect(typeof a.position).toBe('number');
+    expect(b.position).toBeGreaterThan(a.position);
+    reorderIntegrations([b.id, a.id]);
+    const ordered = listIntegrations().filter((r) => r.name.startsWith(tag));
+    expect(ordered[0].id).toBe(b.id);
+    expect(ordered[1].id).toBe(a.id);
+  } finally {
+    deleteIntegration(a.id);
+    deleteIntegration(b.id);
+  }
 });

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -256,7 +256,7 @@ export function createIntegration(input: Omit<IntegrationRow, 'id' | 'position'>
 
 export function updateIntegration(
   id: number,
-  input: Omit<IntegrationRow, 'id'>,
+  input: Omit<IntegrationRow, 'id' | 'position'>,
 ): IntegrationRow | null {
   db.query(
     'UPDATE integrations SET name=$name, type=$type, config=$config, enabled=$enabled, refresh_seconds=$rs WHERE id=$id',

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -283,8 +283,9 @@ export function reorderIntegrations(orderedIds: number[]): void {
   tx(orderedIds);
 }
 
-export function replaceAllIntegrations(rows: IntegrationRow[]): void {
-  const tx = db.transaction((list: IntegrationRow[]) => {
+export function replaceAllIntegrations(rows: Array<Omit<IntegrationRow, 'position'> & { position?: number }>): void {
+  type RowIn = Omit<IntegrationRow, 'position'> & { position?: number };
+  const tx = db.transaction((list: RowIn[]) => {
     db.query('DELETE FROM integrations').run();
     const stmt = db.query(
       'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds, position) VALUES ($id,$name,$type,$config,$enabled,$rs,$pos)',

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -260,3 +260,23 @@ export function updateIntegration(
 export function deleteIntegration(id: number): void {
   db.query('DELETE FROM integrations WHERE id = $id').run({ $id: id });
 }
+
+export function replaceAllIntegrations(rows: IntegrationRow[]): void {
+  const tx = db.transaction((list: IntegrationRow[]) => {
+    db.query('DELETE FROM integrations').run();
+    const stmt = db.query(
+      'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds) VALUES ($id,$name,$type,$config,$enabled,$rs)',
+    );
+    for (const r of list) {
+      stmt.run({
+        $id: r.id,
+        $name: r.name,
+        $type: r.type,
+        $config: JSON.stringify(r.config),
+        $enabled: r.enabled ? 1 : 0,
+        $rs: r.refreshSeconds,
+      });
+    }
+  });
+  tx(rows);
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -127,6 +127,14 @@ const migrations = [
       ON CONFLICT(key) DO UPDATE SET value = excluded.value;
     `,
   },
+  {
+    version: 5,
+    name: 'integration_position',
+    up: `
+      ALTER TABLE integrations ADD COLUMN position INTEGER;
+      UPDATE integrations SET position = id WHERE position IS NULL;
+    `,
+  },
 ];
 
 export function runMigrations() {
@@ -197,6 +205,7 @@ export type IntegrationRow = {
   config: Record<string, unknown>;
   enabled: boolean;
   refreshSeconds: number | null;
+  position: number;
 };
 
 type Raw = {
@@ -206,6 +215,7 @@ type Raw = {
   config: string;
   enabled: number;
   refresh_seconds: number | null;
+  position: number | null;
 };
 const toRow = (r: Raw): IntegrationRow => ({
   id: r.id,
@@ -214,10 +224,11 @@ const toRow = (r: Raw): IntegrationRow => ({
   config: JSON.parse(r.config),
   enabled: !!r.enabled,
   refreshSeconds: r.refresh_seconds,
+  position: r.position ?? r.id,
 });
 
 export function listIntegrations(): IntegrationRow[] {
-  return (db.query('SELECT * FROM integrations ORDER BY id').all() as Raw[]).map(toRow);
+  return (db.query('SELECT * FROM integrations ORDER BY position, id').all() as Raw[]).map(toRow);
 }
 
 export function getIntegration(id: number): IntegrationRow | null {
@@ -225,10 +236,12 @@ export function getIntegration(id: number): IntegrationRow | null {
   return r ? toRow(r) : null;
 }
 
-export function createIntegration(input: Omit<IntegrationRow, 'id'>): IntegrationRow {
+export function createIntegration(input: Omit<IntegrationRow, 'id' | 'position'>): IntegrationRow {
+  const nextPos =
+    (db.query('SELECT COALESCE(MAX(position), 0) + 1 AS p FROM integrations').get() as { p: number }).p;
   const info = db
     .query(
-      'INSERT INTO integrations (name, type, config, enabled, refresh_seconds) VALUES ($name,$type,$config,$enabled,$rs)',
+      'INSERT INTO integrations (name, type, config, enabled, refresh_seconds, position) VALUES ($name,$type,$config,$enabled,$rs,$pos)',
     )
     .run({
       $name: input.name,
@@ -236,6 +249,7 @@ export function createIntegration(input: Omit<IntegrationRow, 'id'>): Integratio
       $config: JSON.stringify(input.config),
       $enabled: input.enabled ? 1 : 0,
       $rs: input.refreshSeconds,
+      $pos: nextPos,
     });
   return getIntegration(Number(info.lastInsertRowid)) as IntegrationRow;
 }
@@ -261,11 +275,19 @@ export function deleteIntegration(id: number): void {
   db.query('DELETE FROM integrations WHERE id = $id').run({ $id: id });
 }
 
+export function reorderIntegrations(orderedIds: number[]): void {
+  const tx = db.transaction((ids: number[]) => {
+    const stmt = db.query('UPDATE integrations SET position = $pos WHERE id = $id');
+    ids.forEach((id, idx) => stmt.run({ $id: id, $pos: idx }));
+  });
+  tx(orderedIds);
+}
+
 export function replaceAllIntegrations(rows: IntegrationRow[]): void {
   const tx = db.transaction((list: IntegrationRow[]) => {
     db.query('DELETE FROM integrations').run();
     const stmt = db.query(
-      'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds) VALUES ($id,$name,$type,$config,$enabled,$rs)',
+      'INSERT INTO integrations (id, name, type, config, enabled, refresh_seconds, position) VALUES ($id,$name,$type,$config,$enabled,$rs,$pos)',
     );
     for (const r of list) {
       stmt.run({
@@ -275,6 +297,7 @@ export function replaceAllIntegrations(rows: IntegrationRow[]): void {
         $config: JSON.stringify(r.config),
         $enabled: r.enabled ? 1 : 0,
         $rs: r.refreshSeconds,
+        $pos: r.position ?? r.id,
       });
     }
   });

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -277,8 +277,20 @@ export function deleteIntegration(id: number): void {
 
 export function reorderIntegrations(orderedIds: number[]): void {
   const tx = db.transaction((ids: number[]) => {
+    // Reposition the whole set, not just the ids passed: any row omitted from a
+    // partial reorder would otherwise keep its old position and collide with the
+    // new 0-based values, making list order non-deterministic. Honor the given
+    // order first, then append the rest by their current order.
+    const all = (db.query('SELECT id FROM integrations ORDER BY position, id').all() as { id: number }[]).map(
+      (r) => r.id,
+    );
+    const known = new Set(all);
+    const seen = new Set<number>();
+    const full: number[] = [];
+    for (const id of ids) if (known.has(id) && !seen.has(id)) (seen.add(id), full.push(id));
+    for (const id of all) if (!seen.has(id)) full.push(id);
     const stmt = db.query('UPDATE integrations SET position = $pos WHERE id = $id');
-    ids.forEach((id, idx) => stmt.run({ $id: id, $pos: idx }));
+    full.forEach((id, idx) => stmt.run({ $id: id, $pos: idx }));
   });
   tx(orderedIds);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
 import { app } from './app';
+import { migrateLayoutToIntegrations } from './config/migrate-layout';
 import { loadConfig } from './config/loader';
 import { initScheduler } from './sse/scheduler';
 
@@ -7,6 +8,7 @@ const PORT = Number(process.env.LABBY_PORT ?? 8080);
 async function main() {
   console.log('Loading config from SQLite database');
 
+  migrateLayoutToIntegrations();
   const state = await loadConfig();
   if (!state.ok) {
     // Invalid config is a degraded (not fatal) state by design: the dashboard

--- a/src/server/integrations/favicon.test.ts
+++ b/src/server/integrations/favicon.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 function mockHtml(html: string) {
   globalThis.fetch = (async () =>
-    new Response(html, { headers: { 'content-type': 'text/html' } })) as typeof fetch;
+    new Response(html, { headers: { 'content-type': 'text/html' } })) as unknown as typeof fetch;
 }
 
 describe('resolveFavicon', () => {
@@ -32,7 +32,7 @@ describe('resolveFavicon', () => {
   it('returns fallback icon when the fetch throws', async () => {
     globalThis.fetch = (async () => {
       throw new Error('network');
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const out = await resolveFavicon('https://example.com');
     expect(out.icon).toBe('https://example.com/favicon.ico');
   });

--- a/src/server/integrations/favicon.test.ts
+++ b/src/server/integrations/favicon.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { resolveFavicon } from './favicon';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function mockHtml(html: string) {
+  globalThis.fetch = (async () =>
+    new Response(html, { headers: { 'content-type': 'text/html' } })) as typeof fetch;
+}
+
+describe('resolveFavicon', () => {
+  it('parses <link rel="icon"> and resolves to an absolute URL', async () => {
+    mockHtml('<html><head><link rel="icon" href="/assets/fav.png"></head></html>');
+    const out = await resolveFavicon('https://example.com/dashboard');
+    expect(out.icon).toBe('https://example.com/assets/fav.png');
+  });
+
+  it('falls back to /favicon.ico when no link tag is present', async () => {
+    mockHtml('<html><head></head></html>');
+    const out = await resolveFavicon('https://example.com/x/y');
+    expect(out.icon).toBe('https://example.com/favicon.ico');
+  });
+
+  it('returns null icon when the URL is invalid', async () => {
+    const out = await resolveFavicon('not a url');
+    expect(out.icon).toBeNull();
+  });
+
+  it('returns fallback icon when the fetch throws', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network');
+    }) as typeof fetch;
+    const out = await resolveFavicon('https://example.com');
+    expect(out.icon).toBe('https://example.com/favicon.ico');
+  });
+});

--- a/src/server/integrations/favicon.ts
+++ b/src/server/integrations/favicon.ts
@@ -5,11 +5,30 @@ const LINK_ICON_RE =
   /<link[^>]+rel=["'][^"']*\bicon\b[^"']*["'][^>]*>/i;
 const HREF_RE = /href=["']([^"']+)["']/i;
 
+const MAX_HTML_BYTES = 512 * 1024;
+
+// ponytail: literal-host SSRF guard, not DNS-rebind proof — blocks the obvious
+// loopback/private/link-local (incl. cloud metadata 169.254.169.254) targets a
+// bookmark URL could otherwise point the server at. Redirects still `follow`, so
+// a public host redirecting to a private IP is not covered; upgrade to a
+// resolve-then-check + redirect:'manual' loop if that becomes a real concern.
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (h === '::1' || h === '0.0.0.0') return true;
+  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+  if (/^169\.254\./.test(h)) return true;
+  if (/^(fc|fd)[0-9a-f]{2}:/.test(h) || /^fe80:/.test(h)) return true;
+  return false;
+}
+
 export async function resolveFavicon(pageUrl: string): Promise<{ icon: string | null }> {
   let base: URL;
   try {
     base = new URL(pageUrl);
     if (base.protocol !== 'http:' && base.protocol !== 'https:') return { icon: null };
+    if (isBlockedHost(base.hostname)) return { icon: null };
   } catch {
     return { icon: null };
   }
@@ -22,7 +41,9 @@ export async function resolveFavicon(pageUrl: string): Promise<{ icon: string | 
       redirect: 'follow',
     });
     if (!res.ok) return { icon: fallback };
-    const html = await res.text();
+    // Cap how much we buffer: a hostile/misconfigured host could stream MBs.
+    if (Number(res.headers.get('content-length') ?? 0) > MAX_HTML_BYTES) return { icon: fallback };
+    const html = (await res.text()).slice(0, MAX_HTML_BYTES);
     const tag = LINK_ICON_RE.exec(html);
     const href = tag ? HREF_RE.exec(tag[0])?.[1] : undefined;
     if (href) {

--- a/src/server/integrations/favicon.ts
+++ b/src/server/integrations/favicon.ts
@@ -1,0 +1,40 @@
+import { TIMEOUT_MS } from './http';
+
+// ponytail: regex parse, not a full HTML parser — swap in a parser if it misses real-world sites
+const LINK_ICON_RE =
+  /<link[^>]+rel=["'][^"']*\bicon\b[^"']*["'][^>]*>/i;
+const HREF_RE = /href=["']([^"']+)["']/i;
+
+export async function resolveFavicon(pageUrl: string): Promise<{ icon: string | null }> {
+  let base: URL;
+  try {
+    base = new URL(pageUrl);
+    if (base.protocol !== 'http:' && base.protocol !== 'https:') return { icon: null };
+  } catch {
+    return { icon: null };
+  }
+
+  const fallback = new URL('/favicon.ico', base).href;
+
+  try {
+    const res = await fetch(base.href, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: 'follow',
+    });
+    if (!res.ok) return { icon: fallback };
+    const html = await res.text();
+    const tag = LINK_ICON_RE.exec(html);
+    const href = tag ? HREF_RE.exec(tag[0])?.[1] : undefined;
+    if (href) {
+      try {
+        return { icon: new URL(href, base).href };
+      } catch {
+        return { icon: fallback };
+      }
+    }
+    return { icon: fallback };
+  } catch {
+    // unreachable host / timeout: still offer the conventional path
+    return { icon: fallback };
+  }
+}

--- a/src/server/integrations/registry.test.ts
+++ b/src/server/integrations/registry.test.ts
@@ -17,6 +17,7 @@ const ALL_TYPES: IntegrationType[] = [
   'weather',
   'calendar',
   'speedtest',
+  'bookmarks',
 ];
 
 const TYPES_WITH_ACTIONS: IntegrationType[] = [
@@ -32,8 +33,8 @@ const TYPES_WITHOUT_ACTIONS: IntegrationType[] = ALL_TYPES.filter(
 );
 
 describe('INTEGRATIONS registry', () => {
-  it('has exactly 15 entries', () => {
-    expect(Object.keys(INTEGRATIONS).length).toBe(15);
+  it('has exactly 16 entries', () => {
+    expect(Object.keys(INTEGRATIONS).length).toBe(16);
   });
 
   it('every type has a truthy label', () => {
@@ -105,11 +106,20 @@ describe('INTEGRATIONS registry', () => {
       expect(INTEGRATIONS[type].actions).toBeUndefined();
     }
   });
+
+  it('bookmarks.fetch returns links from config', async () => {
+    const out = (await INTEGRATIONS.bookmarks.fetch({
+      links: [{ title: 'Router', url: 'http://192.168.1.1' }],
+    })) as { links: unknown[] };
+    expect(out.links.length).toBe(1);
+    const empty = (await INTEGRATIONS.bookmarks.fetch({})) as { links: unknown[] };
+    expect(empty.links).toEqual([]);
+  });
 });
 
 describe('integrationTypes()', () => {
-  it('returns an array of 15 entries', () => {
-    expect(integrationTypes().length).toBe(15);
+  it('returns an array of 16 entries', () => {
+    expect(integrationTypes().length).toBe(16);
   });
 
   it('omits fetch and actions from entries', () => {

--- a/src/server/integrations/registry.test.ts
+++ b/src/server/integrations/registry.test.ts
@@ -117,6 +117,20 @@ describe('INTEGRATIONS registry', () => {
   });
 });
 
+describe('display-option fields', () => {
+  it('monitor exposes variant and style display fields', () => {
+    const keys = INTEGRATIONS.monitor.fields.map((f) => f.key);
+    expect(keys).toContain('variant');
+    expect(keys).toContain('style');
+  });
+
+  it('feed/arr/calendar/download/beszel types expose a max field', () => {
+    for (const t of ['qbittorrent', 'transmission', 'beszel', 'radarr', 'sonarr', 'reelward', 'reddit', 'hackernews', 'calendar'] as const) {
+      expect(INTEGRATIONS[t].fields.map((f) => f.key)).toContain('max');
+    }
+  });
+});
+
 describe('integrationTypes()', () => {
   it('returns an array of 16 entries', () => {
     expect(integrationTypes().length).toBe(16);

--- a/src/server/integrations/registry.ts
+++ b/src/server/integrations/registry.ts
@@ -55,7 +55,11 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
   monitor: {
     label: 'Monitor',
     defaultRefreshSeconds: 30,
-    fields: [{ key: 'sites', label: 'Sites', kind: 'list' }],
+    fields: [
+      { key: 'sites', label: 'Sites', kind: 'list' },
+      { key: 'variant', label: 'Display', kind: 'select', options: ['rows', 'tiles'] },
+      { key: 'style', label: 'Density', kind: 'select', options: ['default', 'compact'] },
+    ],
     fetch: (c) => checkSites(c as MonitorConfig),
   },
   docker: {
@@ -82,6 +86,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
       { key: 'url', label: 'URL' },
       { key: 'user', label: 'User' },
       { key: 'pass', label: 'Password', secret: true },
+      { key: 'max', label: 'Max items', kind: 'number' },
     ],
     fetch: (c) => getQBittorrentTorrents(c as QbitConfig),
     actions: {
@@ -96,6 +101,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
       { key: 'url', label: 'URL' },
       { key: 'user', label: 'User' },
       { key: 'pass', label: 'Password', secret: true },
+      { key: 'max', label: 'Max items', kind: 'number' },
     ],
     fetch: (c) => getTransmissionTorrents(c as TransmissionConfig),
     actions: {
@@ -134,6 +140,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
       { key: 'user', label: 'User' },
       { key: 'pass', label: 'Password', secret: true },
       { key: 'token', label: 'Token', secret: true },
+      { key: 'max', label: 'Max systems', kind: 'number' },
     ],
     fetch: (c) => getBeszelSystems(c as BeszelConfig),
   },
@@ -143,6 +150,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
+      { key: 'max', label: 'Max items', kind: 'number' },
     ],
     fetch: (c) => getArrSummary(c as ArrConfig, 'radarr'),
   },
@@ -152,6 +160,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
+      { key: 'max', label: 'Max items', kind: 'number' },
     ],
     fetch: (c) => getArrSummary(c as ArrConfig, 'sonarr'),
   },
@@ -161,19 +170,23 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
+      { key: 'max', label: 'Max items', kind: 'number' },
     ],
     fetch: (c) => getReelwardSummary(c as ReelwardConfig),
   },
   reddit: {
     label: 'Reddit',
     defaultRefreshSeconds: 240,
-    fields: [{ key: 'subreddits', label: 'Subreddits', kind: 'list' }],
+    fields: [
+      { key: 'subreddits', label: 'Subreddits', kind: 'list' },
+      { key: 'max', label: 'Max items', kind: 'number' },
+    ],
     fetch: (c) => getRedditPosts(c as RedditConfig),
   },
   hackernews: {
     label: 'Hacker News',
     defaultRefreshSeconds: 240,
-    fields: [],
+    fields: [{ key: 'max', label: 'Max items', kind: 'number' }],
     fetch: (c) => getHackerNews(c as HNConfig),
   },
   weather: {
@@ -191,7 +204,10 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
   calendar: {
     label: 'Calendar',
     defaultRefreshSeconds: 600,
-    fields: [{ key: 'icsUrls', label: 'ICS URLs', kind: 'list' }],
+    fields: [
+      { key: 'icsUrls', label: 'ICS URLs', kind: 'list' },
+      { key: 'max', label: 'Max events', kind: 'number' },
+    ],
     fetch: (c) => getCalendarEvents(c as CalendarConfig),
   },
   speedtest: {

--- a/src/server/integrations/registry.ts
+++ b/src/server/integrations/registry.ts
@@ -51,6 +51,9 @@ export type IntegrationDef = {
   actions?: Record<string, (config: Record<string, unknown>, ...args: any[]) => Promise<unknown>>;
 };
 
+// Shared "max items to show" field used by most list-style widgets.
+const MAX_FIELD: FieldDef = { key: 'max', label: 'Max items', kind: 'number' };
+
 export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
   monitor: {
     label: 'Monitor',
@@ -86,7 +89,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
       { key: 'url', label: 'URL' },
       { key: 'user', label: 'User' },
       { key: 'pass', label: 'Password', secret: true },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getQBittorrentTorrents(c as QbitConfig),
     actions: {
@@ -101,7 +104,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
       { key: 'url', label: 'URL' },
       { key: 'user', label: 'User' },
       { key: 'pass', label: 'Password', secret: true },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getTransmissionTorrents(c as TransmissionConfig),
     actions: {
@@ -150,7 +153,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getArrSummary(c as ArrConfig, 'radarr'),
   },
@@ -160,7 +163,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getArrSummary(c as ArrConfig, 'sonarr'),
   },
@@ -170,7 +173,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     fields: [
       { key: 'url', label: 'URL' },
       { key: 'apiKey', label: 'API Key', secret: true },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getReelwardSummary(c as ReelwardConfig),
   },
@@ -179,14 +182,14 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     defaultRefreshSeconds: 240,
     fields: [
       { key: 'subreddits', label: 'Subreddits', kind: 'list' },
-      { key: 'max', label: 'Max items', kind: 'number' },
+      MAX_FIELD,
     ],
     fetch: (c) => getRedditPosts(c as RedditConfig),
   },
   hackernews: {
     label: 'Hacker News',
     defaultRefreshSeconds: 240,
-    fields: [{ key: 'max', label: 'Max items', kind: 'number' }],
+    fields: [MAX_FIELD],
     fetch: (c) => getHackerNews(c as HNConfig),
   },
   weather: {

--- a/src/server/integrations/registry.ts
+++ b/src/server/integrations/registry.ts
@@ -32,7 +32,8 @@ export type IntegrationType =
   | 'hackernews'
   | 'weather'
   | 'calendar'
-  | 'speedtest';
+  | 'speedtest'
+  | 'bookmarks';
 
 export type FieldDef = {
   key: string;
@@ -204,6 +205,15 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
     actions: {
       run: (c) => triggerSpeedtestRun(c as SpeedtestConfig),
     },
+  },
+  bookmarks: {
+    label: 'Bookmarks',
+    // ponytail: static links, no polling — large interval so the no-op re-publish is rare
+    defaultRefreshSeconds: 86_400,
+    fields: [{ key: 'links', label: 'Links', kind: 'list' }],
+    fetch: async (c) => ({
+      links: Array.isArray(c.links) ? (c.links as Array<Record<string, unknown>>) : [],
+    }),
   },
 };
 

--- a/src/web/src/App.svelte
+++ b/src/web/src/App.svelte
@@ -6,56 +6,28 @@
   import { onMount } from 'svelte';
 
   let { config }: { config: Dashboard } = $props();
-  let activePageIndex = $state(0);
-  let page = $derived(config.pages[activePageIndex] || config.pages[0]);
-  let integrationsById = $state<Map<number, IntegrationRow>>(new Map());
+  let integrations = $state<IntegrationRow[]>([]);
+
+  const visible = $derived(
+    [...integrations].filter((r) => r.enabled).sort((a, b) => a.position - b.position || a.id - b.id),
+  );
 
   onMount(() => {
     void fetch('/api/integrations')
       .then((res) => (res.ok ? res.json() : []))
       .then((rows: IntegrationRow[]) => {
-        integrationsById = new Map(rows.map((r) => [r.id, r]));
+        integrations = rows;
       });
     return initStream();
   });
 </script>
 
-<Header {config} />
+<Header {config} {integrations} />
 
 <main class="page">
-  {#if config.pages.length > 1}
-    <div class="page-h">
-      <div class="page-tabs" role="tablist" aria-label="Dashboard pages">
-        {#each config.pages as p, idx}
-          <button
-            class="page-tab"
-            class:active={activePageIndex === idx}
-            role="tab"
-            aria-selected={activePageIndex === idx}
-            onclick={() => (activePageIndex = idx)}
-          >{p.name}</button>
-        {/each}
-      </div>
-    </div>
-  {/if}
-
-  {#if config.theme?.layout === 'columns'}
-    <div class="grid-columns">
-      {#each page.columns as col}
-        <div class="grid-column {col.size}">
-          {#each col.widgets as widget}
-            <WidgetHost {widget} integrationType={integrationsById.get(widget.integrationId)?.type} />
-          {/each}
-        </div>
-      {/each}
-    </div>
-  {:else}
-    <div class="grid">
-      {#each page.columns as col}
-        {#each col.widgets as widget}
-          <WidgetHost {widget} integrationType={integrationsById.get(widget.integrationId)?.type} />
-        {/each}
-      {/each}
-    </div>
-  {/if}
+  <div class="grid">
+    {#each visible as integration (integration.id)}
+      <WidgetHost {integration} />
+    {/each}
+  </div>
 </main>

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -306,12 +306,43 @@
     window.location.href = '/api/backup';
   }
 
+  let dragIndex = $state<number | null>(null);
+
+  async function persistOrder() {
+    try {
+      await fetch('/api/integrations/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: rows.map((r) => r.id) }),
+      });
+    } catch {
+      /* order will resync on next load */
+    }
+  }
+
+  function onDragStart(i: number) {
+    dragIndex = i;
+  }
+  function onDragOver(e: DragEvent, i: number) {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === i) return;
+    const next = [...rows];
+    const [moved] = next.splice(dragIndex, 1);
+    next.splice(i, 0, moved);
+    rows = next;
+    dragIndex = i;
+  }
+  function onDrop() {
+    dragIndex = null;
+    void persistOrder();
+  }
+
   async function onImportFile(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
     const file = input.files?.[0];
     input.value = '';
     if (!file) return;
-    if (!confirm('This replaces ALL services and your dashboard layout with the backup’s contents. Continue?')) return;
+    if (!confirm("This replaces ALL services and your dashboard layout with the backup's contents. Continue?")) return;
     importing = true;
     error = null;
     try {
@@ -358,9 +389,18 @@
     </div>
   {:else}
     <div class="services-grid">
-      {#each rows as row}
-        <div class="svc-card">
+      {#each rows as row, i (row.id)}
+        <div
+          class="svc-card"
+          class:dragging={dragIndex === i}
+          draggable="true"
+          ondragstart={() => onDragStart(i)}
+          ondragover={(e) => onDragOver(e, i)}
+          ondrop={onDrop}
+          ondragend={onDrop}
+        >
           <div class="svc-head">
+            <span class="drag-handle" aria-hidden="true" title="Drag to reorder">⠿</span>
             <span class="svc-mark"><Icon icon={TYPE_ICONS[row.type] ?? 'lucide:box'} fallback="box" size={20} /></span>
             <div class="svc-title">
               <h3>{row.name}</h3>
@@ -1148,4 +1188,16 @@
       gap: 12px;
     }
   }
+
+  .svc-card[draggable='true'] { cursor: default; }
+  .svc-card.dragging { opacity: 0.5; }
+  .drag-handle {
+    cursor: grab;
+    color: var(--ink-faint);
+    font-size: 18px;
+    line-height: 1;
+    user-select: none;
+    padding-right: 2px;
+  }
+  .drag-handle:active { cursor: grabbing; }
 </style>

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -35,6 +35,7 @@
     weather: '/icons/openweather.png',
     calendar: 'lucide:calendar',
     speedtest: '/icons/speedtest-tracker.svg',
+    bookmarks: 'lucide:layout-grid',
   };
 
   const selectedMeta = $derived(types.find((t) => t.type === formType));
@@ -128,6 +129,36 @@
     updateSite(key, i, { okCodes: codes.length ? codes : undefined });
   }
 
+  // --- bookmarks links editor ---
+  type LinkForm = { title?: string; url?: string; icon?: string };
+  function links(key: string): LinkForm[] {
+    const v = formConfig[key];
+    return Array.isArray(v) ? (v as LinkForm[]) : [];
+  }
+  function addLink(key: string) {
+    formConfig = { ...formConfig, [key]: [...links(key), { title: '', url: '', icon: '' }] };
+  }
+  function removeLink(key: string, i: number) {
+    formConfig = { ...formConfig, [key]: links(key).filter((_, idx) => idx !== i) };
+  }
+  function updateLink(key: string, i: number, patch: Partial<LinkForm>) {
+    formConfig = {
+      ...formConfig,
+      [key]: links(key).map((l, idx) => (idx === i ? { ...l, ...patch } : l)),
+    };
+  }
+  async function fetchFavicon(key: string, i: number) {
+    const link = links(key)[i];
+    if (!link?.url?.trim() || link.icon?.trim()) return;
+    try {
+      const res = await fetch(`/api/favicon?url=${encodeURIComponent(link.url.trim())}`);
+      const data = (await res.json()) as { icon: string | null };
+      if (data.icon) updateLink(key, i, { icon: data.icon });
+    } catch {
+      /* leave icon empty — falls back to a glyph */
+    }
+  }
+
   // --- calendar feeds: stored as "Name|URL" strings (URL only if unnamed) ---
   type CalForm = { name?: string; url?: string };
   function cals(key: string): CalForm[] {
@@ -176,6 +207,14 @@
           const pipe = s.indexOf('|');
           return (pipe > 0 ? s.slice(pipe + 1).trim() : s).length > 0;
         });
+      } else if (k === 'links' && Array.isArray(v)) {
+        out[k] = (v as LinkForm[])
+          .map((l) => ({
+            title: (l.title ?? '').trim() || (l.url ?? '').trim(),
+            url: (l.url ?? '').trim(),
+            ...(l.icon?.trim() ? { icon: l.icon.trim() } : {}),
+          }))
+          .filter((l) => l.url);
       }
     }
     return out;
@@ -422,6 +461,39 @@
               {/each}
               <button type="button" class="btn-add-site" onclick={() => addCal(field.key)}>
                 <Plus size={14} /> Add calendar
+              </button>
+            </div>
+          {:else if field.key === 'links'}
+            <div class="sites-editor">
+              {#each links(field.key) as l, i}
+                <div class="site-row">
+                  <input
+                    type="text"
+                    placeholder="Title"
+                    value={l.title ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { title: e.currentTarget.value })}
+                  />
+                  <input
+                    type="text"
+                    placeholder="https://service.lan"
+                    value={l.url ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { url: e.currentTarget.value })}
+                    onblur={() => fetchFavicon(field.key, i)}
+                  />
+                  <input
+                    type="text"
+                    placeholder="Icon (auto)"
+                    value={l.icon ?? ''}
+                    oninput={(e) => updateLink(field.key, i, { icon: e.currentTarget.value })}
+                  />
+                  <span class="ibox"><Icon icon={l.icon ?? ''} fallback="globe" size={18} /></span>
+                  <button type="button" class="btn-icon danger" onclick={() => removeLink(field.key, i)} aria-label="Remove link" title="Remove link">
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              {/each}
+              <button type="button" class="btn-add-site" onclick={() => addLink(field.key)}>
+                <Plus size={14} /> Add link
               </button>
             </div>
           {:else if field.kind === 'list'}

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -407,7 +407,7 @@
           ondragstart={() => onDragStart(i)}
           ondragover={(e) => onDragOver(e, i)}
           ondrop={onDrop}
-          ondragend={onDrop}
+          ondragend={() => (dragIndex = null)}
         >
           <div class="svc-head">
             <span class="drag-handle" aria-hidden="true" title="Drag to reorder">⠿</span>

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -298,6 +298,40 @@
       saving = false;
     }
   }
+
+  let importing = $state(false);
+  let fileInput = $state<HTMLInputElement | null>(null);
+
+  function exportBackup() {
+    window.location.href = '/api/backup';
+  }
+
+  async function onImportFile(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+    if (!confirm('This replaces ALL services and your dashboard layout with the backup’s contents. Continue?')) return;
+    importing = true;
+    error = null;
+    try {
+      const text = await file.text();
+      const res = await fetch('/api/restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: text,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Failed to restore backup');
+      }
+      window.location.reload();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to restore backup';
+    } finally {
+      importing = false;
+    }
+  }
 </script>
 
 <div class="page settings-page">
@@ -310,6 +344,22 @@
       <h1>Manage Services</h1>
       <p class="settings-sub">Add integrations with URLs, API keys, and per-instance settings. Everything is stored in the SQLite database — credentials never leave the server.</p>
     </div>
+    <div class="settings-actions">
+      <button type="button" class="btn-cancel" onclick={exportBackup} title="Download a full backup (includes credentials)">
+        Export backup
+      </button>
+      <button type="button" class="btn-cancel" onclick={() => fileInput?.click()} disabled={importing}>
+        {importing ? 'Importing…' : 'Import backup'}
+      </button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept="application/json"
+        style="display:none"
+        onchange={onImportFile}
+      />
+    </div>
+    <p class="settings-sub" style="margin-top:6px">⚠️ Backups contain plaintext credentials — store them securely.</p>
   </div>
 
   {#if error}
@@ -600,6 +650,14 @@
     font-weight: 500;
     margin-top: 6px;
     max-width: 56ch;
+  }
+  .settings-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-shrink: 0;
+    margin-left: auto;
+    margin-top: 4px;
   }
 
   .services-grid {

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { ArrowLeft, Database, Eye, EyeOff, Pencil, Plus, Trash2 } from 'lucide-svelte';
+  import { ArrowLeft, Database, Download, Eye, EyeOff, Pencil, Plus, TriangleAlert, Trash2, Upload } from 'lucide-svelte';
   import Icon from './components/Icon.svelte';
   import type { FieldDef, IntegrationRow, IntegrationTypeMeta } from '$lib/types';
 
@@ -344,22 +344,6 @@
       <h1>Manage Services</h1>
       <p class="settings-sub">Add integrations with URLs, API keys, and per-instance settings. Everything is stored in the SQLite database — credentials never leave the server.</p>
     </div>
-    <div class="settings-actions">
-      <button type="button" class="btn-cancel" onclick={exportBackup} title="Download a full backup (includes credentials)">
-        Export backup
-      </button>
-      <button type="button" class="btn-cancel" onclick={() => fileInput?.click()} disabled={importing}>
-        {importing ? 'Importing…' : 'Import backup'}
-      </button>
-      <input
-        bind:this={fileInput}
-        type="file"
-        accept="application/json"
-        style="display:none"
-        onchange={onImportFile}
-      />
-    </div>
-    <p class="settings-sub" style="margin-top:6px">⚠️ Backups contain plaintext credentials — store them securely.</p>
   </div>
 
   {#if error}
@@ -415,6 +399,33 @@
       </div>
     </div>
   {/if}
+
+  <section class="backup" aria-labelledby="backup-title">
+    <div class="backup-head">
+      <span class="settings-eyebrow"><Database size={13} /> Backup &amp; restore</span>
+      <h2 id="backup-title">Move your setup</h2>
+      <p class="settings-sub">Download everything — services, credentials, and your dashboard layout — as one file, or restore from a previous one.</p>
+    </div>
+    <div class="backup-warn">
+      <TriangleAlert size={16} />
+      <span>The file includes your service credentials in plain text. Keep it somewhere private.</span>
+    </div>
+    <div class="backup-actions">
+      <button type="button" class="btn-save" onclick={exportBackup}>
+        <Download size={16} /> Export backup
+      </button>
+      <button type="button" class="btn-cancel" onclick={() => fileInput?.click()} disabled={importing}>
+        <Upload size={16} /> {importing ? 'Importing…' : 'Import backup'}
+      </button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept="application/json"
+        style="display:none"
+        onchange={onImportFile}
+      />
+    </div>
+  </section>
 </div>
 
 {#if formOpen && selectedMeta}
@@ -515,31 +526,31 @@
             </div>
           {:else if field.key === 'links'}
             <div class="sites-editor">
-              {#each links(field.key) as l, i}
+              {#each links(field.key) as l, i (i)}
                 <div class="site-row">
-                  <input
-                    type="text"
-                    placeholder="Title"
-                    value={l.title ?? ''}
-                    oninput={(e) => updateLink(field.key, i, { title: e.currentTarget.value })}
-                  />
-                  <input
-                    type="text"
-                    placeholder="https://service.lan"
-                    value={l.url ?? ''}
-                    oninput={(e) => updateLink(field.key, i, { url: e.currentTarget.value })}
-                    onblur={() => fetchFavicon(field.key, i)}
-                  />
-                  <input
-                    type="text"
-                    placeholder="Icon (auto)"
-                    value={l.icon ?? ''}
-                    oninput={(e) => updateLink(field.key, i, { icon: e.currentTarget.value })}
-                  />
-                  <span class="ibox"><Icon icon={l.icon ?? ''} fallback="globe" size={18} /></span>
-                  <button type="button" class="btn-icon danger" onclick={() => removeLink(field.key, i)} aria-label="Remove link" title="Remove link">
-                    <Trash2 size={15} />
-                  </button>
+                  <div class="site-row-head">
+                    <span class="site-badge">
+                      <Icon icon={l.icon?.trim() || 'lucide:globe'} fallback="globe" size={18} />
+                    </span>
+                    <span class="site-row-title">{l.title?.trim() || l.url?.trim() || `Link ${i + 1}`}</span>
+                    <button type="button" class="btn-icon danger" onclick={() => removeLink(field.key, i)} aria-label="Remove link" title="Remove link">
+                      <Trash2 size={15} />
+                    </button>
+                  </div>
+                  <div class="site-grid">
+                    <label class="sub-field">
+                      Name
+                      <input type="text" placeholder="Proxmox" value={l.title ?? ''} oninput={(e) => updateLink(field.key, i, { title: e.currentTarget.value })} />
+                    </label>
+                    <label class="sub-field">
+                      Icon <span class="opt">auto-filled from the link</span>
+                      <input type="text" placeholder="di:proxmox" value={l.icon ?? ''} oninput={(e) => updateLink(field.key, i, { icon: e.currentTarget.value })} />
+                    </label>
+                    <label class="sub-field span2">
+                      Link URL
+                      <input type="text" placeholder="https://proxmox.lan:8006" value={l.url ?? ''} oninput={(e) => updateLink(field.key, i, { url: e.currentTarget.value })} onblur={() => fetchFavicon(field.key, i)} />
+                    </label>
+                  </div>
                 </div>
               {/each}
               <button type="button" class="btn-add-site" onclick={() => addLink(field.key)}>
@@ -651,13 +662,51 @@
     margin-top: 6px;
     max-width: 56ch;
   }
-  .settings-actions {
+  .backup {
+    margin-top: 36px;
+    padding-top: 26px;
+    border-top: 1px solid var(--glass-brd);
+  }
+  .backup-head h2 {
+    font-size: 1.15rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    margin-top: 2px;
+  }
+  .backup-head .settings-sub {
+    margin-top: 6px;
+    margin-bottom: 16px;
+  }
+  .backup-warn {
     display: flex;
-    gap: 8px;
+    align-items: flex-start;
+    gap: 10px;
+    max-width: 60ch;
+    padding: 12px 14px;
+    margin-bottom: 18px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--warn) 13%, transparent);
+    border: 1px solid color-mix(in srgb, var(--warn) 40%, transparent);
+    color: var(--ink);
+    font-size: 0.85rem;
+    font-weight: 500;
+    line-height: 1.45;
+  }
+  .backup-warn :global(svg) {
+    flex: none;
+    margin-top: 1px;
+    color: var(--warn);
+  }
+  .backup-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .backup-actions button {
+    display: inline-flex;
     align-items: center;
-    flex-shrink: 0;
-    margin-left: auto;
-    margin-top: 4px;
+    gap: 8px;
   }
 
   .services-grid {

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { ArrowLeft, Database, Download, Eye, EyeOff, Pencil, Plus, TriangleAlert, Trash2, Upload } from 'lucide-svelte';
+  import { ArrowLeft, ChevronDown, ChevronUp, Database, Download, Eye, EyeOff, Pencil, Plus, TriangleAlert, Trash2, Upload } from 'lucide-svelte';
   import Icon from './components/Icon.svelte';
   import type { FieldDef, IntegrationRow, IntegrationTypeMeta } from '$lib/types';
 
@@ -337,6 +337,16 @@
     void persistOrder();
   }
 
+  // Touch/keyboard-friendly reorder (HTML5 drag doesn't fire on iOS Safari).
+  function move(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= rows.length) return;
+    const next = [...rows];
+    [next[i], next[j]] = [next[j], next[i]];
+    rows = next;
+    void persistOrder();
+  }
+
   async function onImportFile(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
     const file = input.files?.[0];
@@ -409,6 +419,12 @@
               </span>
             </div>
             <div class="row-actions">
+              <button type="button" class="btn-icon" onclick={() => move(i, -1)} disabled={i === 0} aria-label="Move up" title="Move up">
+                <ChevronUp size={15} />
+              </button>
+              <button type="button" class="btn-icon" onclick={() => move(i, 1)} disabled={i === rows.length - 1} aria-label="Move down" title="Move down">
+                <ChevronDown size={15} />
+              </button>
               <button type="button" class="btn-icon" onclick={() => openEdit(row)} aria-label="Edit" title="Edit">
                 <Pencil size={15} />
               </button>

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -775,8 +775,7 @@ header.top {
 }
 
 @media (max-width: 720px) {
-  .header-time,
-  .custom-select {
+  .header-time {
     display: none !important;
   }
   .top-in {

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -256,7 +256,9 @@
       <span class="chip" title="Services down"><span class="dot down"></span><b>{summary.down}</b></span>
     </div>
 
-    <Select value={theme} options={themes} onchange={quickSetTheme} pill={true} style="width: 170px;" />
+    <span class="quick-theme">
+      <Select value={theme} options={themes} onchange={quickSetTheme} pill={true} style="width: 170px;" />
+    </span>
 
     <button class="iconbtn" onclick={() => window.location.hash = '#settings'} aria-label="Manage services" title="Manage services">
       <Database size={17} />
@@ -305,3 +307,12 @@
     </div>
   </Modal>
 {/if}
+
+<style>
+  /* On phones the quick theme picker lives in the Customize modal instead. */
+  @media (max-width: 720px) {
+    .quick-theme {
+      display: none;
+    }
+  }
+</style>

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -5,7 +5,7 @@
   import Select from './Select.svelte';
   import { get } from 'svelte/store';
   import { getStore, streamConnected, type MonitorData, type WidgetState } from '$lib/stores';
-  import type { Dashboard } from '$lib/types';
+  import type { Dashboard, IntegrationRow } from '$lib/types';
 
   const themes = [
     ['system', 'System Default'],
@@ -33,11 +33,10 @@
     ['dark-peach', 'Peach (Dark)'],
   ] as const;
 
-  let { config }: { config: Dashboard } = $props();
+  let { config, integrations = [] }: { config: Dashboard; integrations?: IntegrationRow[] } = $props();
   const title = $derived(config.title ?? 'Labby');
 
   let theme = $state(config.theme?.default ?? 'system');
-  let layout = $state(config.theme?.layout ?? 'masonry');
   let density = $state<'default' | 'compact'>('compact');
   let customCss = $state(config.theme?.customCss ?? '');
   let settingsOpen = $state(false);
@@ -45,17 +44,9 @@
 
   let currentTime = $state('');
 
-  const monitorIds = $derived.by(() => {
-    const ids = new Set<number>();
-    for (const page of config.pages) {
-      for (const col of page.columns) {
-        for (const w of col.widgets) {
-          if (w.type === 'monitor') ids.add(w.integrationId);
-        }
-      }
-    }
-    return [...ids];
-  });
+  const monitorIds = $derived(
+    integrations.filter((r) => r.type === 'monitor' && r.enabled).map((r) => r.id),
+  );
 
   let summary = $state({ up: 0, warn: 0, down: 0 });
 
@@ -139,11 +130,6 @@
     }
   }
 
-  function previewLayout(next: 'masonry' | 'columns') {
-    layout = next;
-    config.theme.layout = next;
-  }
-
   function previewDensity(next: 'default' | 'compact') {
     density = next;
     config.theme.density = next;
@@ -180,7 +166,6 @@
 
   function openSettings() {
     theme = config.theme?.default ?? 'system';
-    layout = config.theme?.layout ?? 'masonry';
     density = config.theme?.density ?? 'default';
     customCss = config.theme?.customCss ?? '';
     settingsOpen = true;
@@ -196,10 +181,8 @@
       document.documentElement.dataset.theme = originalTheme;
     }
     theme = originalTheme;
-    config.theme.layout = config.theme?.layout ?? 'masonry';
     config.theme.density = config.theme?.density ?? 'default';
     config.theme.customCss = config.theme?.customCss ?? '';
-    layout = config.theme?.layout ?? 'masonry';
     density = config.theme?.density ?? 'default';
     document.documentElement.dataset.density = density;
     customCss = config.theme?.customCss ?? '';
@@ -213,14 +196,12 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           theme: theme,
-          layout: layout,
           density: density,
           customCss: customCss,
         }),
       });
       if (res.ok) {
         config.theme.default = theme;
-        config.theme.layout = layout;
         config.theme.density = density;
         config.theme.customCss = customCss;
         try {
@@ -293,21 +274,6 @@
       <div class="settings-group">
         <label for="settings-theme">Theme</label>
         <Select id="settings-theme" value={theme} options={themes} onchange={previewTheme} pill={false} style="width: 100%;" />
-      </div>
-
-      <div class="settings-group">
-        <span class="settings-label">Layout</span>
-        <div class="settings-radio-group">
-          <label class="radio-label">
-            <input type="radio" name="layout" value="masonry" checked={layout === 'masonry'} onchange={() => previewLayout('masonry')} />
-            <span>Masonry</span>
-          </label>
-          <label class="radio-label">
-            <input type="radio" name="layout" value="columns" checked={layout === 'columns'} onchange={() => previewLayout('columns')} />
-            <span>Columns</span>
-          </label>
-        </div>
-        <p class="settings-help">Masonry packs widgets to fill vertical gaps. Columns keeps them exactly where you arranged them.</p>
       </div>
 
       <div class="settings-group">

--- a/src/web/src/components/WidgetHost.svelte
+++ b/src/web/src/components/WidgetHost.svelte
@@ -11,6 +11,7 @@
   import Weather from '../widgets/Weather.svelte';
   import Calendar from '../widgets/Calendar.svelte';
   import Speedtest from '../widgets/Speedtest.svelte';
+  import Bookmarks from '../widgets/Bookmarks.svelte';
   import type { Widget } from '$lib/types';
 
   let {
@@ -67,4 +68,6 @@
   <Calendar title={widget.title} integrationId={widget.integrationId} max={widget.max} />
 {:else if widget.type === 'speedtest'}
   <Speedtest title={widget.title} integrationId={widget.integrationId} max={widget.max} />
+{:else if widget.type === 'bookmarks'}
+  <Bookmarks title={widget.title} integrationId={widget.integrationId} />
 {/if}

--- a/src/web/src/components/WidgetHost.svelte
+++ b/src/web/src/components/WidgetHost.svelte
@@ -12,62 +12,40 @@
   import Calendar from '../widgets/Calendar.svelte';
   import Speedtest from '../widgets/Speedtest.svelte';
   import Bookmarks from '../widgets/Bookmarks.svelte';
-  import type { Widget } from '$lib/types';
+  import type { IntegrationRow } from '$lib/types';
 
-  let {
-    widget,
-    integrationType,
-  }: {
-    widget: Widget;
-    integrationType?: string;
-  } = $props();
+  let { integration }: { integration: IntegrationRow } = $props();
+  const c = $derived(integration.config as Record<string, any>);
+  const id = $derived(integration.id);
+  const title = $derived(integration.name);
 </script>
 
-{#if widget.type === 'monitor'}
-  <Monitor
-    title={widget.title}
-    integrationId={widget.integrationId}
-    style={widget.style}
-    variant={widget.variant ?? 'rows'}
-    headerIcon={widget.variant === 'tiles' ? 'lucide:layout-grid' : 'lucide:activity'}
-  />
-{:else if widget.type === 'docker'}
-  <Docker title={widget.title} integrationId={widget.integrationId} />
-{:else if widget.type === 'downloads'}
-  <Downloads
-    title={widget.title}
-    integrationId={widget.integrationId}
-    client={integrationType === 'transmission' ? 'transmission' : 'qbittorrent'}
-    max={widget.max}
-  />
-{:else if widget.type === 'adguard'}
-  <AdGuard title={widget.title} integrationId={widget.integrationId} />
-{:else if widget.type === 'jellyfin'}
-  <Jellyfin title={widget.title} integrationId={widget.integrationId} />
-{:else if widget.type === 'beszel'}
-  <Beszel title={widget.title} integrationId={widget.integrationId} systems={widget.systems} max={widget.max} />
-{:else if widget.type === 'radarr'}
-  <Arr title={widget.title} integrationId={widget.integrationId} kind="radarr" max={widget.max} />
-{:else if widget.type === 'sonarr'}
-  <Arr title={widget.title} integrationId={widget.integrationId} kind="sonarr" max={widget.max} />
-{:else if widget.type === 'reelward'}
-  <Reelward title={widget.title} integrationId={widget.integrationId} max={widget.max} />
-{:else if widget.type === 'reddit'}
-  <Feed
-    title={widget.title}
-    integrationId={widget.integrationId}
-    icon="di:reddit"
-    fallback="message-square"
-    max={widget.max}
-  />
-{:else if widget.type === 'hackernews'}
-  <Feed title={widget.title} integrationId={widget.integrationId} icon="di:hacker-news" fallback="flame" max={widget.max} />
-{:else if widget.type === 'weather'}
-  <Weather title={widget.title} integrationId={widget.integrationId} />
-{:else if widget.type === 'calendar'}
-  <Calendar title={widget.title} integrationId={widget.integrationId} max={widget.max} />
-{:else if widget.type === 'speedtest'}
-  <Speedtest title={widget.title} integrationId={widget.integrationId} max={widget.max} />
-{:else if widget.type === 'bookmarks'}
-  <Bookmarks title={widget.title} integrationId={widget.integrationId} />
+{#if integration.type === 'monitor'}
+  <Monitor {title} integrationId={id} style={c.style} variant={c.variant ?? 'rows'} headerIcon={c.variant === 'tiles' ? 'lucide:layout-grid' : 'lucide:activity'} />
+{:else if integration.type === 'docker'}
+  <Docker {title} integrationId={id} />
+{:else if integration.type === 'qbittorrent' || integration.type === 'transmission'}
+  <Downloads {title} integrationId={id} client={integration.type} max={c.max} />
+{:else if integration.type === 'adguard'}
+  <AdGuard {title} integrationId={id} />
+{:else if integration.type === 'jellyfin'}
+  <Jellyfin {title} integrationId={id} />
+{:else if integration.type === 'beszel'}
+  <Beszel {title} integrationId={id} systems={c.systems} max={c.max} />
+{:else if integration.type === 'radarr' || integration.type === 'sonarr'}
+  <Arr {title} integrationId={id} kind={integration.type} max={c.max} />
+{:else if integration.type === 'reelward'}
+  <Reelward {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'reddit'}
+  <Feed {title} integrationId={id} icon="di:reddit" fallback="message-square" max={c.max} />
+{:else if integration.type === 'hackernews'}
+  <Feed {title} integrationId={id} icon="di:hacker-news" fallback="flame" max={c.max} />
+{:else if integration.type === 'weather'}
+  <Weather {title} integrationId={id} />
+{:else if integration.type === 'calendar'}
+  <Calendar {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'speedtest'}
+  <Speedtest {title} integrationId={id} max={c.max} />
+{:else if integration.type === 'bookmarks'}
+  <Bookmarks {title} integrationId={id} />
 {/if}

--- a/src/web/src/lib/stores.ts
+++ b/src/web/src/lib/stores.ts
@@ -191,6 +191,9 @@ export type FeedData = {
   subreddit?: string;
 };
 
+export type BookmarkLink = { title: string; url: string; icon?: string };
+export type BookmarksData = { links: BookmarkLink[] };
+
 export type WidgetState<T> = {
   loading: boolean;
   error: string | null;

--- a/src/web/src/lib/types.ts
+++ b/src/web/src/lib/types.ts
@@ -26,7 +26,8 @@ export type Widget =
   | { type: 'hackernews'; title: string; integrationId: number; max?: number }
   | { type: 'weather'; title: string; integrationId: number }
   | { type: 'calendar'; title: string; integrationId: number; max?: number }
-  | { type: 'speedtest'; title: string; integrationId: number; max?: number };
+  | { type: 'speedtest'; title: string; integrationId: number; max?: number }
+  | { type: 'bookmarks'; title: string; integrationId: number };
 
 export type Column = { size: 'small' | 'full'; widgets: Widget[] };
 export type Page = { name: string; columns: Column[] };

--- a/src/web/src/lib/types.ts
+++ b/src/web/src/lib/types.ts
@@ -6,32 +6,6 @@ export type Site = {
   okCodes?: number[];
 };
 
-export type Widget =
-  | {
-      type: 'monitor';
-      title: string;
-      integrationId: number;
-      style?: 'compact' | 'default';
-      variant?: 'rows' | 'tiles';
-    }
-  | { type: 'docker'; title: string; integrationId: number }
-  | { type: 'downloads'; title: string; integrationId: number; max?: number }
-  | { type: 'adguard'; title: string; integrationId: number }
-  | { type: 'jellyfin'; title: string; integrationId: number }
-  | { type: 'beszel'; title: string; integrationId: number; systems?: string[]; max?: number }
-  | { type: 'radarr'; title: string; integrationId: number; max?: number }
-  | { type: 'sonarr'; title: string; integrationId: number; max?: number }
-  | { type: 'reelward'; title: string; integrationId: number; max?: number }
-  | { type: 'reddit'; title: string; integrationId: number; max?: number }
-  | { type: 'hackernews'; title: string; integrationId: number; max?: number }
-  | { type: 'weather'; title: string; integrationId: number }
-  | { type: 'calendar'; title: string; integrationId: number; max?: number }
-  | { type: 'speedtest'; title: string; integrationId: number; max?: number }
-  | { type: 'bookmarks'; title: string; integrationId: number };
-
-export type Column = { size: 'small' | 'full'; widgets: Widget[] };
-export type Page = { name: string; columns: Column[] };
-
 export type LayoutType = 'masonry' | 'columns';
 
 export type ThemeName =
@@ -67,7 +41,6 @@ export type Dashboard = {
     density?: 'default' | 'compact';
     customCss?: string;
   };
-  pages: Page[];
 };
 
 export type IntegrationRow = {
@@ -77,6 +50,7 @@ export type IntegrationRow = {
   config: Record<string, unknown>;
   enabled: boolean;
   refreshSeconds: number | null;
+  position: number;
 };
 
 export type FieldDef = {

--- a/src/web/src/widgets/Bookmarks.svelte
+++ b/src/web/src/widgets/Bookmarks.svelte
@@ -7,6 +7,13 @@
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<BookmarksData>);
   const links = $derived(state.data?.links ?? []);
+
+  // Svelte does not strip dangerous schemes from href; only allow http(s) or
+  // a same-origin path so a stored `javascript:` URL can't execute on click.
+  function safeHref(u?: string): string {
+    const s = (u ?? '').trim();
+    return /^https?:\/\//i.test(s) || s.startsWith('/') ? s : '#';
+  }
 </script>
 
 <section class="card">
@@ -27,7 +34,7 @@
   {:else}
     <div class="bm-grid">
       {#each links as l}
-        <a class="bm-tile" href={l.url} target="_blank" rel="noopener">
+        <a class="bm-tile" href={safeHref(l.url)} target="_blank" rel="noopener">
           <span class="bm-ico"><Icon icon={l.icon ?? ''} fallback="globe" size={22} /></span>
           <span class="bm-label">{l.title}</span>
         </a>

--- a/src/web/src/widgets/Bookmarks.svelte
+++ b/src/web/src/widgets/Bookmarks.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import Icon from '../components/Icon.svelte';
+  import { getStore, type BookmarksData, type WidgetState } from '$lib/stores';
+
+  let { title, integrationId }: { title: string; integrationId: number } = $props();
+
+  const store = $derived(getStore(integrationId));
+  const state = $derived($store as WidgetState<BookmarksData>);
+  const links = $derived(state.data?.links ?? []);
+</script>
+
+<section class="card">
+  <div class="chead">
+    <span class="ti">
+      <span class="ibox"><Icon icon="lucide:layout-grid" fallback="layout-grid" size={18} /></span>
+      {title}
+    </span>
+    {#if links.length}<span class="meta">{links.length}</span>{/if}
+  </div>
+
+  {#if state.loading && !state.data}
+    <div class="skeleton" style="height:96px"></div>
+  {:else if state.error}
+    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+  {:else if links.length === 0}
+    <p class="state-msg">No bookmarks</p>
+  {:else}
+    <div class="bm-grid">
+      {#each links as l}
+        <a class="bm-tile" href={l.url} target="_blank" rel="noopener">
+          <span class="bm-ico"><Icon icon={l.icon ?? ''} fallback="globe" size={22} /></span>
+          <span class="bm-label">{l.title}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .bm-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+    gap: 8px;
+  }
+  .bm-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 8px;
+    border-radius: var(--radius, 10px);
+    background: var(--surface-2, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    text-decoration: none;
+    transition: background 0.15s ease;
+  }
+  .bm-tile:hover {
+    background: var(--surface-3, rgba(127, 127, 127, 0.16));
+  }
+  .bm-label {
+    font-size: 0.78rem;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .bm-tile { transition: none; }
+  }
+</style>


### PR DESCRIPTION
## What

Reworks the dashboard around the integrations table and adds two features on top.

### Integration-driven layout (breaking)
- Dashboard now renders from **ordered integrations**, not `pages`/`columns`. Schema shrunk to `title` + `theme` + display-option fields; layout lives on integration rows.
- Integrations carry a `position` column; new reorder endpoint + helper.
- **Drag-and-drop reordering** on Manage Services, with up/down buttons as an iOS/keyboard fallback.
- One-time migration folds the old `pages`/`columns` layout into integration order — existing dashboards upgrade automatically.

### Bookmarks widget
- New bookmarks widget + links editor with favicon auto-fetch.

### Backup
- Full backup **export/import** endpoints (guarded parse, Content-Disposition), buttons in Manage Services footer, scheduler restarts after restore.

### Fixes
- Mobile: theme Select hidden in Customize modal (global `.custom-select` hide also killed the modal's picker — now scoped to the header quick-picker only).
- Header theme picker hidden on mobile (use Customize modal).
- favicon mock cast for tsc.

## Breaking / upgrade
Dashboard JSON schema changed (no more `pages`/`columns`). A built-in migration converts existing layouts into ordered integrations on first boot — no manual action, but it is a one-way schema change.

## Testing
- `bun test` — 149 pass / 0 fail.
- `bun run build` — clean.