### PR TITLE
chore: release 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labby",
-  "version": "1.5.0-beta.3",
+  "version": "1.5.0",
   "private": true,
   "license": "MIT",
   "description": "Self-hosted homelab dashboard: one Bun process serving a JSON API, a Svelte SPA, and an SSE stream.",


### PR DESCRIPTION
Promote 1.5.0-beta.3 → stable 1.5.0.

Ships since v1.4.0:
- Emby now-playing integration
- SABnzbd download integration
- Plex integration (server-side image proxy, SSRF guard)
- MediaSessions widget consolidation
- Per-device reorder controls (drag on desktop, arrows on touch)
- Settings icon fixes for new integrations