### PR TITLE
feat(docker): connect to the Docker socket directly (no proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Configure everything from the **Manage Services** page — no `.env` file or fla
 | Type | What to configure |
 | --- | --- |
 | `monitor` | HTTP sites to check (title, URL, icon per site) |
-| `docker` | Read/write Docker hosts, container filter (`running` / `all`) |
+| `docker` | Read/write Docker hosts, container filter (`running` / `all`) — see [Docker host](#docker-host) |
 | `qbittorrent` | URL, username, password |
 | `transmission` | URL, username, password |
 | `sabnzbd` | URL, API key |
@@ -94,6 +94,15 @@ Configure everything from the **Manage Services** page — no `.env` file or fla
 | `hackernews` | No config (Algolia front page) |
 
 You can add multiple integrations of the same type (e.g. two Radarr instances) — each gets its own row, poll interval, and SSE channel (`int:<id>`).
+
+#### Docker host
+
+The **Read host** / **Write host** fields accept either:
+
+- A **TCP endpoint** — `tcp://host:2375` or `http://host:2375`. Docker does **not** expose this by default; point it at a [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) (recommended — lets you allow reads but deny writes) or at a daemon with the TCP API enabled.
+- A **unix socket** — `/var/run/docker.sock` or `unix:///var/run/docker.sock`, mounted into the Labby container. No proxy needed; point both **Read host** and **Write host** at the socket.
+
+> **The socket grants full, root-equivalent control of the Docker daemon** ([docs](https://docs.docker.com/engine/security/protect-access/)). A `:ro` bind mount only makes the socket *file* read-only on the host — it does **not** restrict the Docker API, so anything that can reach the socket can still start/stop/delete containers. It is **not** a read-only connection. If you want true read/write separation (allow status, deny control), use the [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) TCP option above instead and point **Write host** at a proxy that denies POST. The container must also be able to reach the socket — run Labby as a uid in the `docker` group, or matching the socket's owner.
 
 ### Icons
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labby",
-  "version": "1.5.0",
+  "version": "1.5.1-beta-1",
   "private": true,
   "license": "MIT",
   "description": "Self-hosted homelab dashboard: one Bun process serving a JSON API, a Svelte SPA, and an SSE stream.",

--- a/src/server/integrations/docker.test.ts
+++ b/src/server/integrations/docker.test.ts
@@ -8,7 +8,33 @@ import {
 
 describe('docker helpers', () => {
   test('dockerHost strips tcp prefix', () => {
-    expect(dockerHost('tcp://docker-proxy-ro:2375')).toBe('http://docker-proxy-ro:2375');
+    expect(dockerHost('tcp://docker-proxy-ro:2375')).toEqual({
+      base: 'http://docker-proxy-ro:2375',
+    });
+  });
+
+  test('dockerHost passes http through', () => {
+    expect(dockerHost('http://docker-proxy-ro:2375/')).toEqual({
+      base: 'http://docker-proxy-ro:2375',
+    });
+  });
+
+  test('dockerHost treats a filesystem path as a unix socket', () => {
+    expect(dockerHost('/var/run/docker.sock')).toEqual({
+      base: 'http://localhost',
+      unix: '/var/run/docker.sock',
+    });
+  });
+
+  test('dockerHost accepts unix:// scheme', () => {
+    expect(dockerHost('unix:///var/run/docker.sock')).toEqual({
+      base: 'http://localhost',
+      unix: '/var/run/docker.sock',
+    });
+  });
+
+  test('dockerHost returns null for empty input', () => {
+    expect(dockerHost(undefined)).toBeNull();
   });
 
   test('normalizeContainerName strips leading slash', () => {

--- a/src/server/integrations/docker.test.ts
+++ b/src/server/integrations/docker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   calcCpuPercent,
   demuxDockerLogs,
+  dockerFetch,
   dockerHost,
   normalizeContainerName,
 } from '../integrations/docker';
@@ -35,6 +36,40 @@ describe('docker helpers', () => {
 
   test('dockerHost returns null for empty input', () => {
     expect(dockerHost(undefined)).toBeNull();
+    expect(dockerHost('   ')).toBeNull();
+  });
+
+  test('dockerHost trims whitespace and trailing slash on socket paths', () => {
+    expect(dockerHost(' /var/run/docker.sock/ ')).toEqual({
+      base: 'http://localhost',
+      unix: '/var/run/docker.sock',
+    });
+  });
+
+  test('dockerHost drops a unix:// authority component', () => {
+    expect(dockerHost('unix://localhost/var/run/docker.sock')).toEqual({
+      base: 'http://localhost',
+      unix: '/var/run/docker.sock',
+    });
+  });
+
+  test('dockerFetch forwards the unix socket path to fetch', async () => {
+    const calls: Array<[string, string | undefined]> = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit & { unix?: string }) => {
+      calls.push([url, init?.unix]);
+      return Promise.resolve(new Response('[]'));
+    }) as typeof fetch;
+    try {
+      await dockerFetch({ base: 'http://localhost', unix: '/var/run/docker.sock' }, '/info');
+      await dockerFetch({ base: 'http://docker-proxy-ro:2375' }, '/info');
+    } finally {
+      globalThis.fetch = orig;
+    }
+    expect(calls).toEqual([
+      ['http://localhost/info', '/var/run/docker.sock'],
+      ['http://docker-proxy-ro:2375/info', undefined],
+    ]);
   });
 
   test('normalizeContainerName strips leading slash', () => {

--- a/src/server/integrations/docker.ts
+++ b/src/server/integrations/docker.ts
@@ -2,18 +2,32 @@ import { TIMEOUT_MS } from './http';
 
 export type DockerConfig = { roHost?: string; rwHost?: string; show?: 'all' | 'running' };
 
-export function dockerHost(host: string | undefined): string | null {
+// A read or write target. `unix` is set when talking to a Docker socket file
+// directly (Bun's fetch dials it); otherwise it's a normal http(s) base URL.
+export type DockerTarget = { base: string; unix?: string };
+
+export function dockerHost(host: string | undefined): DockerTarget | null {
   if (!host) return null;
-  return host.replace(/^tcp:\/\//, 'http://').replace(/\/$/, '');
+  // A unix:// scheme or a bare filesystem path means the Docker socket itself —
+  // no TCP proxy needed. The URL host is ignored by Bun when `unix` is set.
+  if (host.startsWith('unix://') || host.startsWith('/')) {
+    return { base: 'http://localhost', unix: host.replace(/^unix:\/\//, '') };
+  }
+  return { base: host.replace(/^tcp:\/\//, 'http://').replace(/\/$/, '') };
 }
 
 export async function dockerFetch(
-  base: string,
+  target: DockerTarget,
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const url = `${base}${path}`;
-  return fetch(url, { ...init, signal: init?.signal ?? AbortSignal.timeout(TIMEOUT_MS) });
+  const url = `${target.base}${path}`;
+  // `unix` is a Bun extension to fetch options, absent from the DOM RequestInit type.
+  return fetch(url, {
+    ...init,
+    unix: target.unix,
+    signal: init?.signal ?? AbortSignal.timeout(TIMEOUT_MS),
+  } as RequestInit & { unix?: string });
 }
 
 export function demuxDockerLogs(buffer: ArrayBuffer): string {

--- a/src/server/integrations/docker.ts
+++ b/src/server/integrations/docker.ts
@@ -1,4 +1,4 @@
-import { TIMEOUT_MS } from './http';
+import { normalizeBase, TIMEOUT_MS } from './http';
 
 export type DockerConfig = { roHost?: string; rwHost?: string; show?: 'all' | 'running' };
 
@@ -7,13 +7,16 @@ export type DockerConfig = { roHost?: string; rwHost?: string; show?: 'all' | 'r
 export type DockerTarget = { base: string; unix?: string };
 
 export function dockerHost(host: string | undefined): DockerTarget | null {
-  if (!host) return null;
+  const h = normalizeBase(host);
+  if (!h) return null;
   // A unix:// scheme or a bare filesystem path means the Docker socket itself —
   // no TCP proxy needed. The URL host is ignored by Bun when `unix` is set.
-  if (host.startsWith('unix://') || host.startsWith('/')) {
-    return { base: 'http://localhost', unix: host.replace(/^unix:\/\//, '') };
+  if (h.startsWith('unix://') || h.startsWith('/')) {
+    // Strip the scheme plus any authority part (`unix://localhost/run/x.sock`),
+    // keeping the absolute socket path.
+    return { base: 'http://localhost', unix: h.replace(/^unix:\/\/[^/]*/, '') };
   }
-  return { base: host.replace(/^tcp:\/\//, 'http://').replace(/\/$/, '') };
+  return { base: h.replace(/^tcp:\/\//, 'http://') };
 }
 
 export async function dockerFetch(
@@ -22,12 +25,12 @@ export async function dockerFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const url = `${target.base}${path}`;
-  // `unix` is a Bun extension to fetch options, absent from the DOM RequestInit type.
+  // `unix` is Bun's fetch extension for dialing a socket file (typed by bun-types).
   return fetch(url, {
     ...init,
     unix: target.unix,
     signal: init?.signal ?? AbortSignal.timeout(TIMEOUT_MS),
-  } as RequestInit & { unix?: string });
+  });
 }
 
 export function demuxDockerLogs(buffer: ArrayBuffer): string {


### PR DESCRIPTION
## What

Lets the Docker integration talk to `/var/run/docker.sock` directly, in addition to the existing `tcp://host:2375` proxy path.

`dockerHost` now recognizes a `unix://` scheme or a bare filesystem path and returns a `{ base, unix }` target; `dockerFetch` passes Bun's `unix` fetch option through. TCP/HTTP hosts behave exactly as before.

## Why

unRAID (and other hosts that don't expose a TCP Docker API) reported `can't fetch url` — Labby only spoke HTTP/TCP, so users were forced to run a socket-proxy. Now they can mount the socket and skip it. Mount `:ro` for the read host; write actions (start/stop/restart) need write access.

## Changes
- `docker.ts` — `dockerHost` returns `DockerTarget { base, unix? }`; `dockerFetch` threads `unix` through.
- `docker.test.ts` — updated tcp assertion + unix/path/null cases.
- `README.md` — new **Docker host** section (TCP-proxy vs unix-socket).
- version → `1.5.1-beta-1`.

## Test
`bun test` — 171 pass. New helper cases cover tcp/http/unix-path/unix-scheme/null.