### PR TITLE
ci: typecheck + test + lint + build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer push to the same branch/PR cancels the older in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install && cd src/web && bun install
+
+      - name: Test
+        run: bun test
+
+      # build:web (Vite) + build:server (bun bundle) compile the SPA and server.
+      # Skips the `vendor-icons` step so CI needs no CDN network (icons are a
+      # build-time fetch, not a correctness gate).
+      - name: Build web
+        run: bun run build:web
+
+      - name: Build server
+        run: bun run build:server
+
+  lint:
+    name: Lint (biome)
+    runs-on: ubuntu-latest
+    # ponytail: informational only — the existing tree has 21 biome errors.
+    # Flip to required (drop continue-on-error) once they're cleaned up.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
 
+      # --frozen-lockfile: test/build the exact committed dependency graph. A PR
+      # that changes a manifest without its bun.lock fails here instead of
+      # silently resolving a different tree in the runner.
       - name: Install dependencies
-        run: bun install && cd src/web && bun install
+        run: bun install --frozen-lockfile && cd src/web && bun install --frozen-lockfile
 
       - name: Typecheck
         run: bun run typecheck
@@ -42,5 +45,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - run: bun run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: bun install && cd src/web && bun install
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Test
         run: bun test
 
@@ -36,9 +39,6 @@ jobs:
   lint:
     name: Lint (biome)
     runs-on: ubuntu-latest
-    # ponytail: informational only — the existing tree has 21 biome errors.
-    # Flip to required (drop continue-on-error) once they're cleaned up.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:server": "bun build src/server/index.ts --outdir dist --target bun",
     "start": "bun run dist/index.js",
     "test": "bun test",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome check --write",
     "vendor-icons": "bun run scripts/vendor-icons.ts"

--- a/src/server/app.reorder.test.ts
+++ b/src/server/app.reorder.test.ts
@@ -5,8 +5,20 @@ import { createIntegration, deleteIntegration, listIntegrations } from './db';
 test('POST /api/integrations/reorder sets the given order', async () => {
   const tag = '__reorder_api__';
   for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
-  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
-  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  const a = createIntegration({
+    name: `${tag}a`,
+    type: 'radarr',
+    config: {},
+    enabled: true,
+    refreshSeconds: null,
+  });
+  const b = createIntegration({
+    name: `${tag}b`,
+    type: 'sonarr',
+    config: {},
+    enabled: true,
+    refreshSeconds: null,
+  });
   try {
     const res = await app.request('/api/integrations/reorder', {
       method: 'POST',

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -4,7 +4,13 @@ import { type Context, Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { z } from 'zod';
 import { getConfig, getConfigState, reloadConfig, saveThemeSettings } from './config/loader';
-import { DashboardSchema, DensitySchema, LayoutSchema, sanitizeDashboard, ThemeSchema } from './config/schema';
+import {
+  DashboardSchema,
+  DensitySchema,
+  LayoutSchema,
+  sanitizeDashboard,
+  ThemeSchema,
+} from './config/schema';
 import {
   createIntegration,
   db,
@@ -12,16 +18,16 @@ import {
   getIntegration,
   getSetting,
   listIntegrations,
-  replaceAllIntegrations,
   reorderIntegrations,
+  replaceAllIntegrations,
   setSetting,
   updateIntegration,
 } from './db';
 import { containerLogs, type DockerConfig } from './integrations/docker-client';
+import { type EmbyConfig, getEmbyImage } from './integrations/emby';
 import { resolveFavicon } from './integrations/favicon';
-import { getEmbyImage, type EmbyConfig } from './integrations/emby';
-import { getPlexImage, type PlexConfig } from './integrations/plex';
 import { getJellyfinImage, type JellyfinConfig } from './integrations/jellyfin';
+import { getPlexImage, type PlexConfig } from './integrations/plex';
 import { INTEGRATIONS, type IntegrationType, integrationTypes } from './integrations/registry';
 import { hub } from './sse/hub';
 import { refreshIntegration, startScheduler } from './sse/scheduler';
@@ -145,7 +151,7 @@ app.post('/api/integrations/:id/action/:action', async (c) => {
 
 app.get('/api/integrations/:id/jellyfin-image/:itemId', async (c) => {
   const row = getIntegration(Number(c.req.param('id')));
-  if (!row || row.type !== 'jellyfin') return c.json({ error: 'Not found' }, 404);
+  if (row?.type !== 'jellyfin') return c.json({ error: 'Not found' }, 404);
   const result = await getJellyfinImage(row.config as JellyfinConfig, c.req.param('itemId'));
   if ('error' in result) return c.json(result, 502);
   return new Response(result.body, {
@@ -158,7 +164,7 @@ app.get('/api/integrations/:id/jellyfin-image/:itemId', async (c) => {
 
 app.get('/api/integrations/:id/emby-image/:itemId', async (c) => {
   const row = getIntegration(Number(c.req.param('id')));
-  if (!row || row.type !== 'emby') return c.json({ error: 'Not found' }, 404);
+  if (row?.type !== 'emby') return c.json({ error: 'Not found' }, 404);
   const result = await getEmbyImage(row.config as EmbyConfig, c.req.param('itemId'));
   if ('error' in result) return c.json(result, 502);
   return new Response(result.body, {
@@ -170,7 +176,7 @@ app.get('/api/integrations/:id/emby-image/:itemId', async (c) => {
 });
 app.get('/api/integrations/:id/plex-image', async (c) => {
   const row = getIntegration(Number(c.req.param('id')));
-  if (!row || row.type !== 'plex') return c.json({ error: 'Not found' }, 404);
+  if (row?.type !== 'plex') return c.json({ error: 'Not found' }, 404);
   const imagePath = c.req.query('path') ?? '';
   const result = await getPlexImage(row.config as PlexConfig, imagePath);
   if ('error' in result) return c.json(result, 502);
@@ -184,7 +190,7 @@ app.get('/api/integrations/:id/plex-image', async (c) => {
 
 app.get('/api/integrations/:id/logs/:containerId', async (c) => {
   const row = getIntegration(Number(c.req.param('id')));
-  if (!row || row.type !== 'docker') return c.json({ error: 'Not found' }, 404);
+  if (row?.type !== 'docker') return c.json({ error: 'Not found' }, 404);
   const tail = Number(c.req.query('tail') ?? 200);
   const result = await containerLogs(row.config as DockerConfig, c.req.param('containerId'), tail);
   if ('error' in result) return c.json(result, 502);

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
-import { createIntegration, deleteIntegration, listIntegrations, replaceAllIntegrations } from './db';
 import { app } from './app';
+import { deleteIntegration, listIntegrations, replaceAllIntegrations } from './db';
 
 const TAG = '__test_backup__';
 
@@ -14,8 +14,22 @@ test('replaceAllIntegrations wipes then restores rows preserving ids', () => {
   const original = listIntegrations();
   try {
     const restored = [
-      { id: 9001, name: `${TAG}a`, type: 'radarr', config: { url: 'http://a' }, enabled: true, refreshSeconds: 60 },
-      { id: 9002, name: `${TAG}b`, type: 'sonarr', config: {}, enabled: false, refreshSeconds: null },
+      {
+        id: 9001,
+        name: `${TAG}a`,
+        type: 'radarr',
+        config: { url: 'http://a' },
+        enabled: true,
+        refreshSeconds: 60,
+      },
+      {
+        id: 9002,
+        name: `${TAG}b`,
+        type: 'sonarr',
+        config: {},
+        enabled: false,
+        refreshSeconds: null,
+      },
     ];
     replaceAllIntegrations(restored);
     const after = listIntegrations();
@@ -44,7 +58,11 @@ test('POST /api/restore rejects a malformed payload with 400 and leaves the DB i
   const res = await app.request('/api/restore', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ version: 1, dashboard: { title: 'x', theme: { default: 'not-a-valid-theme' } }, integrations: [] }),
+    body: JSON.stringify({
+      version: 1,
+      dashboard: { title: 'x', theme: { default: 'not-a-valid-theme' } },
+      integrations: [],
+    }),
   });
   expect(res.status).toBe(400);
   expect(listIntegrations().length).toBe(before);

--- a/src/server/config/loader.test.ts
+++ b/src/server/config/loader.test.ts
@@ -35,7 +35,10 @@ describe('config loader', () => {
   });
 
   test('loadConfig returns error for schema violation', async () => {
-    setSetting('dashboard', JSON.stringify({ title: 'x', theme: { default: 'not-a-valid-theme' } }));
+    setSetting(
+      'dashboard',
+      JSON.stringify({ title: 'x', theme: { default: 'not-a-valid-theme' } }),
+    );
     const result = await loadConfig();
     expect(result.ok).toBe(false);
   });

--- a/src/server/config/migrate-layout.test.ts
+++ b/src/server/config/migrate-layout.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from 'bun:test';
-import { createIntegration, deleteIntegration, getIntegration, getSetting, listIntegrations, setSetting, deleteSetting } from '../db';
+import {
+  createIntegration,
+  deleteIntegration,
+  deleteSetting,
+  getIntegration,
+  getSetting,
+  listIntegrations,
+  setSetting,
+} from '../db';
 import { migrateLayoutToIntegrations } from './migrate-layout';
 
 test('migration folds widget options + order into integrations and rewrites dashboard', () => {
@@ -9,18 +17,43 @@ test('migration folds widget options + order into integrations and rewrites dash
   const savedFlag = getSetting('layout_migrated');
   deleteSetting('layout_migrated');
 
-  const m = createIntegration({ name: `${tag}mon`, type: 'monitor', config: { sites: [] }, enabled: true, refreshSeconds: null });
-  const f = createIntegration({ name: `${tag}feed`, type: 'reddit', config: { subreddits: ['x'] }, enabled: true, refreshSeconds: null });
+  const m = createIntegration({
+    name: `${tag}mon`,
+    type: 'monitor',
+    config: { sites: [] },
+    enabled: true,
+    refreshSeconds: null,
+  });
+  const f = createIntegration({
+    name: `${tag}feed`,
+    type: 'reddit',
+    config: { subreddits: ['x'] },
+    enabled: true,
+    refreshSeconds: null,
+  });
 
   // legacy dashboard: feed first, monitor second; options on widgets
-  setSetting('dashboard', JSON.stringify({
-    title: 'My Board',
-    theme: { default: 'dark' },
-    pages: [{ name: 'Home', columns: [{ size: 'full', widgets: [
-      { type: 'reddit', integrationId: f.id, max: 9 },
-      { type: 'monitor', integrationId: m.id, variant: 'tiles', style: 'compact' },
-    ] }] }],
-  }));
+  setSetting(
+    'dashboard',
+    JSON.stringify({
+      title: 'My Board',
+      theme: { default: 'dark' },
+      pages: [
+        {
+          name: 'Home',
+          columns: [
+            {
+              size: 'full',
+              widgets: [
+                { type: 'reddit', integrationId: f.id, max: 9 },
+                { type: 'monitor', integrationId: m.id, variant: 'tiles', style: 'compact' },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  );
 
   try {
     migrateLayoutToIntegrations();
@@ -41,6 +74,7 @@ test('migration folds widget options + order into integrations and rewrites dash
     deleteIntegration(m.id);
     deleteIntegration(f.id);
     if (savedDash !== null) setSetting('dashboard', savedDash);
-    if (savedFlag !== null) setSetting('layout_migrated', savedFlag); else deleteSetting('layout_migrated');
+    if (savedFlag !== null) setSetting('layout_migrated', savedFlag);
+    else deleteSetting('layout_migrated');
   }
 });

--- a/src/server/config/migrate-layout.ts
+++ b/src/server/config/migrate-layout.ts
@@ -1,4 +1,11 @@
-import { db, getSetting, listIntegrations, reorderIntegrations, setSetting, updateIntegration } from '../db';
+import {
+  db,
+  getSetting,
+  listIntegrations,
+  reorderIntegrations,
+  setSetting,
+  updateIntegration,
+} from '../db';
 
 const DISPLAY_KEYS = ['max', 'variant', 'style', 'systems'] as const;
 
@@ -14,6 +21,7 @@ export function migrateLayoutToIntegrations(): void {
     return;
   }
 
+  // biome-ignore lint/suspicious/noExplicitAny: loose traversal of untrusted legacy dashboard JSON
   let parsed: any;
   try {
     parsed = JSON.parse(raw);
@@ -50,10 +58,17 @@ export function migrateLayoutToIntegrations(): void {
       reorderIntegrations([...ordered]);
     }
 
-    setSetting('dashboard', JSON.stringify({
-      title: parsed?.title ?? 'Labby',
-      theme: parsed?.theme ?? { default: 'system' },
-    }, null, 2));
+    setSetting(
+      'dashboard',
+      JSON.stringify(
+        {
+          title: parsed?.title ?? 'Labby',
+          theme: parsed?.theme ?? { default: 'system' },
+        },
+        null,
+        2,
+      ),
+    );
     setSetting('layout_migrated', '1');
   })();
 }

--- a/src/server/config/schema.test.ts
+++ b/src/server/config/schema.test.ts
@@ -32,7 +32,11 @@ describe('DashboardSchema', () => {
   });
 
   test('DashboardSchema ignores a legacy pages field', () => {
-    const parsed = DashboardSchema.parse({ title: 'X', theme: { default: 'system' }, pages: [{ junk: true }] });
+    const parsed = DashboardSchema.parse({
+      title: 'X',
+      theme: { default: 'system' },
+      pages: [{ junk: true }],
+    });
     expect((parsed as any).pages).toBeUndefined();
   });
 });

--- a/src/server/db.integrations.test.ts
+++ b/src/server/db.integrations.test.ts
@@ -36,8 +36,20 @@ test('integration CRUD round-trips config as JSON', () => {
 test('position is assigned on create and returned in order', () => {
   const tag = '__pos_test__';
   for (const r of listIntegrations().filter((r) => r.name.startsWith(tag))) deleteIntegration(r.id);
-  const a = createIntegration({ name: `${tag}a`, type: 'radarr', config: {}, enabled: true, refreshSeconds: null });
-  const b = createIntegration({ name: `${tag}b`, type: 'sonarr', config: {}, enabled: true, refreshSeconds: null });
+  const a = createIntegration({
+    name: `${tag}a`,
+    type: 'radarr',
+    config: {},
+    enabled: true,
+    refreshSeconds: null,
+  });
+  const b = createIntegration({
+    name: `${tag}b`,
+    type: 'sonarr',
+    config: {},
+    enabled: true,
+    refreshSeconds: null,
+  });
   try {
     expect(typeof a.position).toBe('number');
     expect(b.position).toBeGreaterThan(a.position);

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -237,8 +237,9 @@ export function getIntegration(id: number): IntegrationRow | null {
 }
 
 export function createIntegration(input: Omit<IntegrationRow, 'id' | 'position'>): IntegrationRow {
-  const nextPos =
-    (db.query('SELECT COALESCE(MAX(position), 0) + 1 AS p FROM integrations').get() as { p: number }).p;
+  const nextPos = (
+    db.query('SELECT COALESCE(MAX(position), 0) + 1 AS p FROM integrations').get() as { p: number }
+  ).p;
   const info = db
     .query(
       'INSERT INTO integrations (name, type, config, enabled, refresh_seconds, position) VALUES ($name,$type,$config,$enabled,$rs,$pos)',
@@ -281,21 +282,29 @@ export function reorderIntegrations(orderedIds: number[]): void {
     // partial reorder would otherwise keep its old position and collide with the
     // new 0-based values, making list order non-deterministic. Honor the given
     // order first, then append the rest by their current order.
-    const all = (db.query('SELECT id FROM integrations ORDER BY position, id').all() as { id: number }[]).map(
-      (r) => r.id,
-    );
+    const all = (
+      db.query('SELECT id FROM integrations ORDER BY position, id').all() as { id: number }[]
+    ).map((r) => r.id);
     const known = new Set(all);
     const seen = new Set<number>();
     const full: number[] = [];
-    for (const id of ids) if (known.has(id) && !seen.has(id)) (seen.add(id), full.push(id));
+    for (const id of ids)
+      if (known.has(id) && !seen.has(id)) {
+        seen.add(id);
+        full.push(id);
+      }
     for (const id of all) if (!seen.has(id)) full.push(id);
     const stmt = db.query('UPDATE integrations SET position = $pos WHERE id = $id');
-    full.forEach((id, idx) => stmt.run({ $id: id, $pos: idx }));
+    full.forEach((id, idx) => {
+      stmt.run({ $id: id, $pos: idx });
+    });
   });
   tx(orderedIds);
 }
 
-export function replaceAllIntegrations(rows: Array<Omit<IntegrationRow, 'position'> & { position?: number }>): void {
+export function replaceAllIntegrations(
+  rows: Array<Omit<IntegrationRow, 'position'> & { position?: number }>,
+): void {
   type RowIn = Omit<IntegrationRow, 'position'> & { position?: number };
   const tx = db.transaction((list: RowIn[]) => {
     db.query('DELETE FROM integrations').run();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 import { app } from './app';
-import { migrateLayoutToIntegrations } from './config/migrate-layout';
 import { loadConfig } from './config/loader';
+import { migrateLayoutToIntegrations } from './config/migrate-layout';
 import { initScheduler } from './sse/scheduler';
 
 const PORT = Number(process.env.LABBY_PORT ?? 8080);

--- a/src/server/integrations/favicon.ts
+++ b/src/server/integrations/favicon.ts
@@ -1,8 +1,7 @@
 import { TIMEOUT_MS } from './http';
 
 // ponytail: regex parse, not a full HTML parser — swap in a parser if it misses real-world sites
-const LINK_ICON_RE =
-  /<link[^>]+rel=["'][^"']*\bicon\b[^"']*["'][^>]*>/i;
+const LINK_ICON_RE = /<link[^>]+rel=["'][^"']*\bicon\b[^"']*["'][^>]*>/i;
 const HREF_RE = /href=["']([^"']+)["']/i;
 
 const MAX_HTML_BYTES = 512 * 1024;

--- a/src/server/integrations/plex.test.ts
+++ b/src/server/integrations/plex.test.ts
@@ -19,7 +19,7 @@ describe('Plex client', () => {
       if (url.includes('/status/sessions')) {
         const headers = init?.headers as Record<string, string>;
         expect(headers['X-Plex-Token']).toBe('plex-tok');
-        expect(headers['Accept']).toBe('application/json');
+        expect(headers.Accept).toBe('application/json');
         return Response.json({
           MediaContainer: {
             size: 2,
@@ -112,7 +112,9 @@ describe('Plex client', () => {
 
   test('image proxy rejects non-relative paths (SSRF guard)', async () => {
     const config: PlexConfig = { url: 'http://plex.test', token: 't' };
-    expect(await getPlexImage(config, 'http://evil.com/x')).toEqual({ error: 'Invalid image path' });
+    expect(await getPlexImage(config, 'http://evil.com/x')).toEqual({
+      error: 'Invalid image path',
+    });
     expect(await getPlexImage(config, '//evil.com/x')).toEqual({ error: 'Invalid image path' });
     expect(await getPlexImage(config, 'library/x')).toEqual({ error: 'Invalid image path' });
   });

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -31,7 +31,11 @@ export async function getPlexSessions(
       const transcode = m.TranscodeSession != null;
       const media = ((m.Media as Record<string, unknown>[]) ?? [])[0];
       const resolution = media?.videoResolution ? String(media.videoResolution) : '';
-      const quality = resolution ? (/^\d+$/.test(resolution) ? `${resolution}p` : resolution) : 'unknown';
+      const quality = resolution
+        ? /^\d+$/.test(resolution)
+          ? `${resolution}p`
+          : resolution
+        : 'unknown';
 
       const year = m.year ? String(m.year) : '';
       const series = m.grandparentTitle ? String(m.grandparentTitle) : '';
@@ -46,11 +50,11 @@ export async function getPlexSessions(
       const user = (m.User as Record<string, unknown>) ?? {};
       const player = (m.Player as Record<string, unknown>) ?? {};
       const thumb =
-      typeof m.thumb === 'string'
-        ? m.thumb
-        : typeof m.grandparentThumb === 'string'
-          ? m.grandparentThumb
-          : undefined;
+        typeof m.thumb === 'string'
+          ? m.thumb
+          : typeof m.grandparentThumb === 'string'
+            ? m.grandparentThumb
+            : undefined;
 
       sessions.push({
         id: String(m.sessionKey ?? m.ratingKey ?? crypto.randomUUID()),

--- a/src/server/integrations/qbittorrent.test.ts
+++ b/src/server/integrations/qbittorrent.test.ts
@@ -139,7 +139,10 @@ describe('qBittorrent client', () => {
   // send hashes in the body, never the URL.
   test('pause sends hashes in the request body, not the query string', async () => {
     const config: QbitConfig = { url: 'http://qb.test', user: 'admin', pass: 'admin' };
-    let captured: { url: string; body: string; contentType: string | null } | null = null;
+    // Array holder, not `let … | null`: a variable assigned only inside the mock
+    // closure collapses to `null` under TS flow analysis, turning `captured?.url`
+    // into a `never` access. Array element reads keep the element type.
+    const captured: { url: string; body: string; contentType: string | null }[] = [];
 
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -147,11 +150,11 @@ describe('qBittorrent client', () => {
       if (url.endsWith('/api/v2/auth/login')) {
         return new Response('Ok.', { status: 200, headers: { 'set-cookie': 'SID=x; path=/' } });
       }
-      captured = {
+      captured.push({
         url,
         body: init?.body ? String(init.body) : '',
         contentType: new Headers(init?.headers).get('Content-Type'),
-      };
+      });
       return new Response('', { status: 200 });
     }) as unknown as typeof fetch;
 
@@ -159,9 +162,9 @@ describe('qBittorrent client', () => {
     globalThis.fetch = originalFetch;
 
     expect(result).toEqual({ ok: true });
-    expect(captured).not.toBeNull();
-    expect(captured?.url).not.toContain('hashes=');
-    expect(captured?.body).toContain('hashes=HASH123');
-    expect(captured?.contentType).toContain('application/x-www-form-urlencoded');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).not.toContain('hashes=');
+    expect(captured[0].body).toContain('hashes=HASH123');
+    expect(captured[0].contentType).toContain('application/x-www-form-urlencoded');
   });
 });

--- a/src/server/integrations/reelward.test.ts
+++ b/src/server/integrations/reelward.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
+import type { ReelwardPayload } from '../types';
 import type { ReelwardConfig } from './reelward';
 import { getReelwardSummary } from './reelward';
 
@@ -12,7 +13,9 @@ describe('Reelward client', () => {
 
   test('maps summary payload', async () => {
     const config: ReelwardConfig = { url: 'http://reelward.test/', apiKey: 'key123' };
-    const payload = { pending: 2, watched: 10, total: 12 };
+    // getReelwardSummary passes the upstream JSON through unchanged; the exact
+    // shape doesn't matter here, only that it round-trips.
+    const payload = { pending: 2, watched: 10, total: 12 } as unknown as ReelwardPayload;
 
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/src/server/integrations/registry.test.ts
+++ b/src/server/integrations/registry.test.ts
@@ -137,7 +137,18 @@ describe('display-option fields', () => {
   });
 
   it('feed/arr/calendar/download/beszel types expose a max field', () => {
-    for (const t of ['qbittorrent', 'transmission', 'sabnzbd', 'beszel', 'radarr', 'sonarr', 'reelward', 'reddit', 'hackernews', 'calendar'] as const) {
+    for (const t of [
+      'qbittorrent',
+      'transmission',
+      'sabnzbd',
+      'beszel',
+      'radarr',
+      'sonarr',
+      'reelward',
+      'reddit',
+      'hackernews',
+      'calendar',
+    ] as const) {
       expect(INTEGRATIONS[t].fields.map((f) => f.key)).toContain('max');
     }
   });

--- a/src/server/integrations/registry.ts
+++ b/src/server/integrations/registry.ts
@@ -1,18 +1,18 @@
 import { type AdGuardConfig, getAdGuardStats, setAdGuardProtection } from './adguard';
-import { getSabnzbdQueue, type SabnzbdConfig, sabnzbdAction } from './sabnzbd';
 import { type ArrConfig, getArrSummary } from './arr';
 import { type BeszelConfig, getBeszelSystems } from './beszel';
 import { type CalendarConfig, getCalendarEvents } from './calendar';
 import { containerAction, containerLogs, type DockerConfig, listContainers } from './docker-client';
+import { type EmbyConfig, getEmbySessions } from './emby';
 import { getHackerNews, type HNConfig } from './hackernews';
-import { getEmbySessions, type EmbyConfig } from './emby';
-import { getPlexSessions, type PlexConfig } from './plex';
 import { getJellyfinSessions, type JellyfinConfig } from './jellyfin';
 import { checkSites, type MonitorConfig } from './monitor';
 import { getOpenWeather, type WeatherConfig } from './openweather';
+import { getPlexSessions, type PlexConfig } from './plex';
 import { getQBittorrentTorrents, type QbitConfig, qbittorrentAction } from './qbittorrent';
 import { getRedditPosts, type RedditConfig } from './reddit';
 import { getReelwardSummary, type ReelwardConfig } from './reelward';
+import { getSabnzbdQueue, type SabnzbdConfig, sabnzbdAction } from './sabnzbd';
 import { getSpeedtestSummary, type SpeedtestConfig, triggerSpeedtestRun } from './speedtest';
 import {
   getTransmissionTorrents,
@@ -54,7 +54,10 @@ export type IntegrationDef = {
   defaultRefreshSeconds: number;
   fields: FieldDef[];
   fetch: (config: Record<string, unknown>) => Promise<unknown>;
-  actions?: Record<string, (config: Record<string, unknown>, ...args: any[]) => Promise<unknown>>;
+  actions?: Record<
+    string,
+    (config: Record<string, unknown>, ...args: unknown[]) => Promise<unknown>
+  >;
 };
 
 // Shared "max items to show" field used by most list-style widgets.
@@ -218,10 +221,7 @@ export const INTEGRATIONS: Record<IntegrationType, IntegrationDef> = {
   reddit: {
     label: 'Reddit',
     defaultRefreshSeconds: 240,
-    fields: [
-      { key: 'subreddits', label: 'Subreddits', kind: 'list' },
-      MAX_FIELD,
-    ],
+    fields: [{ key: 'subreddits', label: 'Subreddits', kind: 'list' }, MAX_FIELD],
     fetch: (c) => getRedditPosts(c as RedditConfig),
   },
   hackernews: {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="__LABBY_THEME__" data-density="default">
 <head>
-<script>(()=> {var a=["light","light-slate","light-mint","light-rose","light-nord","light-peach","dark","dark-graphite","dark-ocean","dark-forest","dark-dracula","dark-nord","dark-cyberpunk","dark-slate","dark-mint","dark-rose","dark-peach","light-graphite","light-ocean","light-forest","light-dracula","light-cyberpunk"],s="__LABBY_THEME__",t;try{t=localStorage.getItem("labby-theme")}catch(e){}
+<script>(()=> {var a=["light","light-slate","light-mint","light-rose","light-nord","light-peach","dark","dark-graphite","dark-ocean","dark-forest","dark-dracula","dark-nord","dark-cyberpunk","dark-slate","dark-mint","dark-rose","dark-peach","light-graphite","light-ocean","light-forest","light-dracula","light-cyberpunk"],s="__LABBY_THEME__",t;try{t=localStorage.getItem("labby-theme")}catch(_e){}
 var sys=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";
 document.documentElement.dataset.theme=a.includes(s)?s:(a.includes(t)?t:sys);
-var d;try{d=localStorage.getItem("labby-density")}catch(e){}
+var d;try{d=localStorage.getItem("labby-density")}catch(_e){}
 document.documentElement.dataset.density=d==="compact"?"compact":"default";
 })();</script>
 <meta charset="UTF-8">

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,5 +1,5 @@
+import path from 'node:path';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import path from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — the repo had **no PR-time CI** (only `docker.yml`, which runs on `v*.*.*` release tags). Also adds a `typecheck` npm script and cleans up the pre-existing lint/type debt so every check is a real, blocking gate.

Runs on every `pull_request` and push to `main`, with concurrency cancellation.

### `Test & build` job
- `bun run typecheck` — `tsc --noEmit` (server + shared TS)
- `bun test` — 167 tests
- `bun run build:web` — Vite SPA compile
- `bun run build:server` — server bundle

Skips the `vendor-icons` CDN fetch so CI is hermetic — icons are a build-time download, not a correctness check.

### `Lint (biome)` job
- `bun run lint` — **blocking** (no longer informational).

## Debt cleaned up to make the gates green

Before this PR the tree had **~20 biome errors** and **2 `tsc` errors**, so nothing could be gated. Fixed:

- **biome** — auto-fixed formatting + import ordering across the tree; `db.ts` comma-operator → block, `forEach` callback no longer returns a value; action-dispatch signature `any[]` → `unknown[]`; one unavoidable `any` (untrusted legacy-JSON traversal in `migrate-layout.ts`) suppressed with a reason.
- **tsc** — `reelward.test.ts` stub typed as `ReelwardPayload`; `qbittorrent.test.ts` uses an array holder so a closure-assigned `let` doesn't collapse to `never`.

## Notes
- `typecheck` is server/shared TS only (root `tsconfig`). The Svelte web app is covered by the Vite build step; adding `svelte-check` would mean a new dependency — out of scope here.
- New code is now held to all four gates.

## Next step (optional)
Add a branch ruleset on `main` requiring **Test & build** + **Lint (biome)** before merge — that's what turns these checks into an enforced gate.