### PR TITLE
fix: keep backups and secrets on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A self-hosted homelab dashboard — lightweight like [Glance](https://github.com
 
 Do not expose Labby to the public internet without network-level access control.
 
+Backups (plaintext, including credentials) are written to `config/backups/` on the server, never returned in an API response.
+
 ## Quick start
 
 Labby runs as a single container. Copy [`docker-compose.yml`](docker-compose.yml) and start it:

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -9,3 +9,7 @@ Do not expose Labby to the public internet without network-level access control.
 ## Credentials
 
 Service credentials are stored server-side in `config/labby.db`. The browser receives sanitized integration metadata and widget data, not the saved secret values.
+
+## Backups
+
+Backups (including stored credentials, in plain text) are written under `config/backups/` on the server. The browser only ever receives the file path, never the backup contents — back up that directory like you would `config/labby.db`.

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -202,3 +202,27 @@ e2e('integration data endpoints stay 200 and serve a stable payload on repeat hi
 
   expect(b).toBe(a);
 }, 30_000);
+
+e2e('backup export stays in the server filesystem', async () => {
+  const page = await browser.newPage();
+  let method = '';
+  await page.route('**/api/backup', async (route) => {
+    method = route.request().method();
+    if (method === 'POST') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ path: 'config/backups/labby-backup-test.json' }),
+      });
+    } else {
+      await route.fulfill({ status: 405 });
+    }
+  });
+
+  await page.goto(`${BASE}/#settings`, { waitUntil: 'load' });
+  await page.getByRole('button', { name: 'Export backup' }).click();
+  await page.waitForTimeout(100);
+  expect(method).toBe('POST');
+  await page.getByText('Saved to config/backups/labby-backup-test.json').waitFor({ state: 'visible', timeout: 5_000 });
+  expect(page.url()).toBe(`${BASE}/#settings`);
+  await page.close();
+}, 30_000);

--- a/src/server/app.integrations.test.ts
+++ b/src/server/app.integrations.test.ts
@@ -47,6 +47,46 @@ test('POST /api/integrations creates a row; GET /api/integrations includes it', 
   }
 });
 
+test('integration responses redact secrets and blank updates preserve them', async () => {
+  cleanup();
+  let id: number | undefined;
+  try {
+    const createRes = await app.request('/api/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: TEST_NAME,
+        type: 'qbittorrent',
+        config: { url: 'http://qbit', user: 'sam', pass: 'stored-secret' },
+        enabled: true,
+      }),
+    });
+    expect(createRes.status).toBe(200);
+    const created = (await createRes.json()) as any;
+    id = created.id;
+    expect(created.config).not.toHaveProperty('pass');
+
+    const list = (await (await app.request('/api/integrations')).json()) as any[];
+    expect(list.find((row) => row.id === id)?.config).not.toHaveProperty('pass');
+
+    const updateRes = await app.request(`/api/integrations/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: TEST_NAME,
+        type: 'qbittorrent',
+        config: { url: 'http://qbit', user: 'sam', pass: '' },
+        enabled: true,
+      }),
+    });
+    expect(updateRes.status).toBe(200);
+    expect((await updateRes.json()).config).not.toHaveProperty('pass');
+    expect(listIntegrations().find((row) => row.id === id)?.config.pass).toBe('stored-secret');
+  } finally {
+    if (id !== undefined) deleteIntegration(id);
+  }
+});
+
 test('GET /api/integrations/:id/data for radarr with empty config returns error (no network)', async () => {
   cleanup();
   let id: number | undefined;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -351,7 +351,7 @@ app.post('/api/backup', async (c) => {
   const tempPath = `${finalPath}.tmp`;
   try {
     await mkdir(backupDir, { recursive: true });
-    await writeFile(tempPath, JSON.stringify(body, null, 2), 'utf8');
+    await writeFile(tempPath, JSON.stringify(body, null, 2), { encoding: 'utf8', mode: 0o600 });
     await rename(tempPath, finalPath);
     return c.json({ path: path.relative(process.cwd(), finalPath) });
   } catch {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { type Context, Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
@@ -13,10 +13,12 @@ import {
 } from './config/schema';
 import {
   createIntegration,
+  DB_PATH,
   db,
   deleteIntegration,
   getIntegration,
   getSetting,
+  type IntegrationRow,
   listIntegrations,
   reorderIntegrations,
   replaceAllIntegrations,
@@ -47,6 +49,33 @@ function themeFromConfig(): string {
 function customCssFromConfig(): string {
   const config = getConfig();
   return config?.theme.customCss ?? '';
+}
+
+function secretKeys(type: string): string[] {
+  return (INTEGRATIONS[type as IntegrationType]?.fields ?? [])
+    .filter((field) => field.secret)
+    .map((field) => field.key);
+}
+
+function publicIntegration(row: IntegrationRow): IntegrationRow {
+  const config = { ...row.config };
+  for (const key of secretKeys(row.type)) delete config[key];
+  return { ...row, config };
+}
+
+function preserveSecrets(
+  existing: IntegrationRow,
+  requestedType: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  if (existing.type !== requestedType) return config;
+  const merged = { ...config };
+  for (const key of secretKeys(existing.type)) {
+    if ((typeof merged[key] !== 'string' || !merged[key].trim()) && key in existing.config) {
+      merged[key] = existing.config[key];
+    }
+  }
+  return merged;
 }
 
 app.use('*', async (c, next) => {
@@ -83,7 +112,7 @@ app.get('/api/favicon', async (c) => {
 
 app.get('/api/integrations/types', (c) => c.json(integrationTypes()));
 
-app.get('/api/integrations', (c) => c.json(listIntegrations()));
+app.get('/api/integrations', (c) => c.json(listIntegrations().map(publicIntegration)));
 
 app.post('/api/integrations', async (c) => {
   const b = await c.req.json();
@@ -96,22 +125,24 @@ app.post('/api/integrations', async (c) => {
     refreshSeconds: b.refreshSeconds ?? null,
   });
   startScheduler();
-  return c.json(row);
+  return c.json(publicIntegration(row));
 });
 
 app.put('/api/integrations/:id', async (c) => {
   const b = await c.req.json();
   if (!b.name || !b.type) return c.json({ error: 'name and type required' }, 400);
-  const row = updateIntegration(Number(c.req.param('id')), {
+  const id = Number(c.req.param('id'));
+  const existing = getIntegration(id);
+  if (!existing) return c.json({ error: 'Not found' }, 404);
+  const row = updateIntegration(id, {
     name: b.name,
     type: b.type,
-    config: b.config ?? {},
+    config: preserveSecrets(existing, b.type, b.config ?? {}),
     enabled: b.enabled ?? true,
     refreshSeconds: b.refreshSeconds ?? null,
   });
-  if (!row) return c.json({ error: 'Not found' }, 404);
   startScheduler();
-  return c.json(row);
+  return c.json(publicIntegration(row as IntegrationRow));
 });
 
 app.delete('/api/integrations/:id', (c) => {
@@ -297,7 +328,7 @@ app.get('/manifest.webmanifest', serveStatic);
 app.get('/sw.js', serveStatic);
 
 // --- backup / restore ---
-app.get('/api/backup', (c) => {
+app.post('/api/backup', async (c) => {
   const dashboardRaw = getSetting('dashboard');
   let dashboard: unknown = null;
   if (dashboardRaw) {
@@ -314,12 +345,19 @@ app.get('/api/backup', (c) => {
     dashboard,
     integrations: listIntegrations(),
   };
-  c.header('Content-Type', 'application/json');
-  c.header(
-    'Content-Disposition',
-    `attachment; filename="labby-backup-${exportedAt.slice(0, 10)}.json"`,
-  );
-  return c.body(JSON.stringify(body, null, 2));
+  const backupDir = path.join(path.dirname(DB_PATH), 'backups');
+  const filename = `labby-backup-${exportedAt.replace(/[:.]/g, '-')}.json`;
+  const finalPath = path.join(backupDir, filename);
+  const tempPath = `${finalPath}.tmp`;
+  try {
+    await mkdir(backupDir, { recursive: true });
+    await writeFile(tempPath, JSON.stringify(body, null, 2), 'utf8');
+    await rename(tempPath, finalPath);
+    return c.json({ path: path.relative(process.cwd(), finalPath) });
+  } catch {
+    await unlink(tempPath).catch(() => {});
+    return c.json({ error: 'Failed to write backup' }, 500);
+  }
 });
 
 const INTEGRATION_TYPES = Object.keys(INTEGRATIONS) as [IntegrationType, ...IntegrationType[]];

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from 'bun:test';
+import { readFile, unlink } from 'node:fs/promises';
+import path from 'node:path';
 import { app } from './app';
-import { deleteIntegration, listIntegrations, replaceAllIntegrations } from './db';
+import {
+  createIntegration,
+  deleteIntegration,
+  listIntegrations,
+  replaceAllIntegrations,
+} from './db';
 
 const TAG = '__test_backup__';
 
@@ -43,14 +50,42 @@ test('replaceAllIntegrations wipes then restores rows preserving ids', () => {
   }
 });
 
-test('GET /api/backup returns version, dashboard, and integrations', async () => {
+test('POST /api/backup writes complete JSON beside the database', async () => {
+  cleanup();
+  const integration = createIntegration({
+    name: `${TAG}secret`,
+    type: 'qbittorrent',
+    config: { pass: 'stored-secret' },
+    enabled: false,
+    refreshSeconds: null,
+  });
+  let filePath: string | undefined;
+  try {
+    const res = await app.request('/api/backup', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string };
+    expect(body.path).toMatch(/backups\/labby-backup-.*\.json$/);
+    filePath = path.resolve(body.path);
+    const saved = JSON.parse(await readFile(filePath, 'utf8')) as {
+      version: number;
+      dashboard: unknown;
+      integrations: Array<{ id: number; config: Record<string, unknown> }>;
+    };
+    expect(saved.version).toBe(1);
+    expect(saved.dashboard).toBeDefined();
+    expect(saved.integrations.find((row) => row.id === integration.id)?.config.pass).toBe(
+      'stored-secret',
+    );
+  } finally {
+    if (filePath) await unlink(filePath).catch(() => {});
+    deleteIntegration(integration.id);
+  }
+});
+
+test('GET /api/backup is not an export download', async () => {
   const res = await app.request('/api/backup');
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as any;
-  expect(body.version).toBe(1);
-  expect(body.dashboard).toBeDefined();
-  expect(Array.isArray(body.integrations)).toBe(true);
-  expect(res.headers.get('Content-Disposition')).toMatch(/attachment; filename="labby-backup-/);
+  expect(res.headers.get('Content-Disposition')).toBeNull();
+  expect(res.headers.get('Content-Type')).toContain('text/html');
 });
 
 test('POST /api/restore rejects a malformed payload with 400 and leaves the DB intact', async () => {
@@ -69,7 +104,11 @@ test('POST /api/restore rejects a malformed payload with 400 and leaves the DB i
 });
 
 test('POST /api/restore round-trips a valid backup', async () => {
-  const original = await (await app.request('/api/backup')).json();
+  const original = {
+    version: 1,
+    dashboard: JSON.parse(await (await app.request('/api/config')).text()),
+    integrations: listIntegrations(),
+  };
   try {
     const res = await app.request('/api/restore', {
       method: 'POST',
@@ -77,8 +116,7 @@ test('POST /api/restore round-trips a valid backup', async () => {
       body: JSON.stringify(original),
     });
     expect(res.status).toBe(200);
-    const again = await (await app.request('/api/backup')).json();
-    expect(again.integrations.length).toBe(original.integrations.length);
+    expect(listIntegrations().length).toBe(original.integrations.length);
   } finally {
     // ensure DB returns to the original snapshot regardless
     await app.request('/api/restore', {

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -85,7 +85,8 @@ test('POST /api/backup writes complete JSON beside the database', async () => {
 test('GET /api/backup is not an export download', async () => {
   const res = await app.request('/api/backup');
   expect(res.headers.get('Content-Disposition')).toBeNull();
-  expect(res.headers.get('Content-Type')).toContain('text/html');
+  const body = await res.text().catch(() => '');
+  expect(body.trimStart().startsWith('{"version"')).toBe(false);
 });
 
 test('POST /api/restore rejects a malformed payload with 400 and leaves the DB intact', async () => {

--- a/src/server/backup.test.ts
+++ b/src/server/backup.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { readFile, unlink } from 'node:fs/promises';
+import { readFile, stat, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { app } from './app';
 import {
@@ -76,6 +76,7 @@ test('POST /api/backup writes complete JSON beside the database', async () => {
     expect(saved.integrations.find((row) => row.id === integration.id)?.config.pass).toBe(
       'stored-secret',
     );
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600);
   } finally {
     if (filePath) await unlink(filePath).catch(() => {});
     deleteIntegration(integration.id);

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,7 +1,7 @@
 import { Database } from 'bun:sqlite';
 import path from 'node:path';
 
-const DB_PATH = process.env.LABBY_DB_PATH ?? path.join(process.cwd(), 'config', 'labby.db');
+export const DB_PATH = process.env.LABBY_DB_PATH ?? path.join(process.cwd(), 'config', 'labby.db');
 
 export const db = new Database(DB_PATH, { create: true });
 

--- a/src/web/src/components/BackupPanel.svelte
+++ b/src/web/src/components/BackupPanel.svelte
@@ -5,10 +5,24 @@
   let { error = $bindable() }: { error?: string | null } = $props();
 
   let importing = $state(false);
+  let exporting = $state(false);
+  let exportedPath = $state<string | null>(null);
   let fileInput = $state<HTMLInputElement | null>(null);
 
-  function exportBackup() {
-    window.location.href = '/api/backup';
+  async function exportBackup() {
+    exporting = true;
+    exportedPath = null;
+    error = null;
+    try {
+      const res = await fetch('/api/backup', { method: 'POST' });
+      const body = (await res.json().catch(() => ({}))) as { path?: string; error?: string };
+      if (!res.ok || !body.path) throw new Error(body.error ?? 'Failed to write backup');
+      exportedPath = body.path;
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to write backup';
+    } finally {
+      exporting = false;
+    }
   }
 
   async function onImportFile(e: Event) {
@@ -43,15 +57,15 @@
   <div class="backup-head">
     <span class="settings-eyebrow"><Database size={13} /> Backup &amp; restore</span>
     <h2 id="backup-title">Move your setup</h2>
-    <p class="settings-sub">Download everything — services, credentials, and your dashboard layout — as one file, or restore from a previous one.</p>
+    <p class="settings-sub">Save everything — services, credentials, and your dashboard layout — to a backup file on this server, or restore from a previous one.</p>
   </div>
   <div class="backup-warn">
     <TriangleAlert size={16} />
-    <span>The file includes your service credentials in plain text. Keep it somewhere private.</span>
+    <span>Backups include your service credentials in plain text and are written to <code>config/backups/</code> on this server — they never leave it.</span>
   </div>
   <div class="backup-actions">
-    <button type="button" class="btn-save" onclick={exportBackup}>
-      <Download size={16} /> Export backup
+    <button type="button" class="btn-save" onclick={exportBackup} disabled={exporting}>
+      <Download size={16} /> {exporting ? 'Saving…' : 'Export backup'}
     </button>
     <button type="button" class="btn-cancel" onclick={() => fileInput?.click()} disabled={importing}>
       <Upload size={16} /> {importing ? 'Importing…' : 'Import backup'}
@@ -64,6 +78,9 @@
       onchange={onImportFile}
     />
   </div>
+  {#if exportedPath}
+    <p class="settings-sub">Saved to {exportedPath}</p>
+  {/if}
 </section>
 
 <style>


### PR DESCRIPTION
## Summary
- GET/POST/PUT `/api/integrations` no longer leak stored secret values to the browser; blank/omitted secret fields on update preserve the existing stored value.
- `POST /api/backup` (was `GET`) writes atomically to `config/backups/` beside the active DB and returns only `{ path }`, never the backup JSON body.
- `BackupPanel.svelte` export button now calls the API and shows "Saved to {path}" instead of navigating to a download URL.
- README.md / docs/guide/security.md updated to match actual behavior.

Fixes labby audit finding: docs claimed secrets were never exposed to the browser, but `GET /api/integrations` returned them directly.

## Test plan
- [x] `bun test` — 179/179 pass (new redaction/preservation test, filesystem-backup-write test, e2e Playwright click-through)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds