### PR TITLE
fix: rebuild modal and keyboard behavior with native <dialog> semantics

### DIFF
--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -226,3 +226,70 @@ e2e('backup export stays in the server filesystem', async () => {
   expect(page.url()).toBe(`${BASE}/#settings`);
   await page.close();
 }, 30_000);
+
+e2e('Customize dialog traps focus, closes on Escape, and returns focus to its trigger', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const trigger = page.getByRole('button', { name: 'Customize interface' });
+  await trigger.click();
+
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+  for (let i = 0; i < 10; i++) await page.keyboard.press('Tab');
+  expect(await page.evaluate(() => !!document.activeElement?.closest('dialog'))).toBe(true);
+
+  await page.keyboard.press('Escape');
+  await dialog.waitFor({ state: 'detached', timeout: 5_000 });
+  expect(await page.evaluate(() => document.activeElement?.getAttribute('aria-label'))).toBe(
+    'Customize interface',
+  );
+
+  await page.close();
+}, 30_000);
+
+e2e('Integration dialog traps focus, closes on backdrop click, and returns focus to its trigger', async () => {
+  const page = await browser.newPage();
+  await page.goto(`${BASE}/#settings`, { waitUntil: 'load' });
+  await page.locator('.svc-card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const trigger = page.locator('.type-pick').first();
+  const triggerLabel = await trigger.textContent();
+  await trigger.click();
+
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+  for (let i = 0; i < 10; i++) await page.keyboard.press('Tab');
+  expect(await page.evaluate(() => !!document.activeElement?.closest('dialog'))).toBe(true);
+
+  await page.mouse.click(2, 2); // far corner, outside the dialog panel
+  await dialog.waitFor({ state: 'detached', timeout: 5_000 });
+  expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toBe(
+    triggerLabel?.trim(),
+  );
+
+  await page.close();
+}, 30_000);
+
+e2e('Service reordering is keyboard-reachable on a desktop (fine pointer) viewport', async () => {
+  const page = await browser.newPage();
+  await page.goto(`${BASE}/#settings`, { waitUntil: 'load' });
+  await page.locator('.svc-card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const moveDown = page.locator('.svc-card').first().locator('button[aria-label="Move down"]');
+  expect(await moveDown.isVisible()).toBe(true);
+
+  const namesBefore = await page.locator('.svc-title h3').allTextContents();
+  await moveDown.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(200);
+  const namesAfter = await page.locator('.svc-title h3').allTextContents();
+
+  expect(namesAfter[0]).toBe(namesBefore[1]);
+  expect(namesAfter[1]).toBe(namesBefore[0]);
+
+  await page.close();
+}, 30_000);

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -432,10 +432,6 @@
   }
   .drag-handle:active { cursor: grabbing; }
 
-  /* Desktop (mouse): drag to reorder, hide arrow buttons. */
-  @media (hover: hover) and (pointer: fine) {
-    .row-actions .move-btn { display: none; }
-  }
   /* Touch: arrow buttons reorder (HTML5 drag doesn't fire on iOS), hide drag handle. */
   @media (pointer: coarse) {
     .drag-handle { display: none; }

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1778,20 +1778,12 @@ header.top {
 }
 
 /* generic modal (Modal.svelte) */
-.modal-bg {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  background: rgba(0, 0, 0, 0.45);
-  -webkit-backdrop-filter: blur(3px);
-  backdrop-filter: blur(3px);
-  display: grid;
-  place-items: center;
-  padding: 24px;
-}
 .modal-panel {
-  width: min(680px, 100%);
-  max-height: 82vh;
+  margin: auto;
+  padding: 0;
+  color: inherit;
+  width: min(680px, calc(100vw - 48px));
+  max-height: min(82vh, calc(100dvh - 48px));
   background: var(--glass);
   -webkit-backdrop-filter: var(--blur);
   backdrop-filter: var(--blur);
@@ -1801,6 +1793,11 @@ header.top {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+.modal-panel::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
 }
 .modal-head {
   display: flex;

--- a/src/web/src/components/IconPicker.svelte
+++ b/src/web/src/components/IconPicker.svelte
@@ -131,13 +131,6 @@
     if (e.key === 'Escape') close();
   }
 
-  // The form modal uses a CSS transform, which would make our position:fixed
-  // popover resolve against the modal instead of the viewport. Portal to <body>.
-  function portal(node: HTMLElement) {
-    document.body.appendChild(node);
-    return { destroy: () => node.remove() };
-  }
-
   // Wire global listeners only while open.
   $effect(() => {
     if (!open) return;
@@ -176,7 +169,7 @@
 </div>
 
 {#if open}
-  <div class="ip-pop" use:portal bind:this={popEl} role="dialog" aria-label="Pick an icon" style={popStyle}>
+  <div class="ip-pop" bind:this={popEl} role="dialog" aria-label="Pick an icon" style={popStyle}>
     <div class="ip-tabs" role="tablist">
       {#each TABS as t}
         <button

--- a/src/web/src/components/IntegrationForm.svelte
+++ b/src/web/src/components/IntegrationForm.svelte
@@ -26,6 +26,22 @@
     oncancel: () => void;
   } = $props();
 
+  let dialogEl = $state<HTMLDialogElement | undefined>();
+
+  $effect(() => {
+    dialogEl?.showModal();
+  });
+
+  // Route every close path through the dialog's own close() so the browser
+  // restores focus to whatever triggered the form before we unmount it.
+  function requestClose() {
+    dialogEl?.close();
+  }
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === dialogEl) requestClose();
+  }
+
   function defaultConfig(fields: FieldDef[]): Record<string, unknown> {
     const cfg: Record<string, unknown> = {};
     for (const f of fields) {
@@ -201,11 +217,16 @@
   }
 </script>
 
-<div class="modal-backdrop" role="presentation" onclick={oncancel}></div>
-<div class="form-panel" role="dialog" aria-labelledby="form-title">
+<dialog
+  bind:this={dialogEl}
+  class="form-panel"
+  aria-labelledby="form-title"
+  onclick={onBackdropClick}
+  onclose={oncancel}
+>
   <div class="form-head">
     <h2 id="form-title">{row ? 'Edit' : 'Add'} {meta.label}</h2>
-    <button type="button" class="iconbtn" onclick={oncancel} aria-label="Close">×</button>
+    <button type="button" class="iconbtn" onclick={requestClose} aria-label="Close">×</button>
   </div>
 
   <div class="svc-fields">
@@ -385,26 +406,18 @@
   </div>
 
   <div class="settings-footer">
-    <button class="btn-cancel" onclick={oncancel}>Cancel</button>
+    <button class="btn-cancel" onclick={requestClose}>Cancel</button>
     <button class="btn-save" onclick={submit} disabled={saving || !formName.trim()}>
       {saving ? 'Saving…' : 'Save'}
     </button>
   </div>
-</div>
+</dialog>
 
 <style>
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    z-index: 100;
-  }
   .form-panel {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 101;
+    margin: auto;
+    padding: 0;
+    color: inherit;
     width: min(560px, calc(100vw - 24px));
     max-height: calc(100dvh - 32px);
     display: flex;
@@ -414,6 +427,9 @@
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     overflow: hidden;
+  }
+  .form-panel::backdrop {
+    background: rgba(0, 0, 0, 0.45);
   }
   .form-head {
     flex: 0 0 auto;

--- a/src/web/src/components/Modal.svelte
+++ b/src/web/src/components/Modal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { fade, fly } from 'svelte/transition';
+  import { fly } from 'svelte/transition';
 
   let {
     title,
@@ -9,28 +9,36 @@
     children,
   }: { title: string; meta?: string; onClose: () => void; children: Snippet } = $props();
 
-  function portal(node: HTMLElement) {
-    document.body.appendChild(node);
-    return {
-      destroy() {
-        if (node.parentNode) {
-          node.parentNode.removeChild(node);
-        }
-      }
-    };
+  let dialogEl = $state<HTMLDialogElement | undefined>();
+
+  $effect(() => {
+    dialogEl?.showModal();
+  });
+
+  // Route every close path through the dialog's own close() so the browser
+  // restores focus to whatever triggered the modal before we unmount it.
+  function requestClose() {
+    dialogEl?.close();
+  }
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === dialogEl) requestClose();
   }
 </script>
 
-<svelte:window onkeydown={(e) => { if (e.key === 'Escape') onClose(); }} />
-
-<div use:portal class="modal-bg" role="presentation" transition:fade={{ duration: 160 }} onclick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-  <div class="modal-panel" role="dialog" aria-modal="true" aria-label={title} tabindex="-1" transition:fly={{ y: 18, duration: 220 }}>
-    <div class="modal-head">
-      <span class="mt">{title}{#if meta}<span class="mm">{meta}</span>{/if}</span>
-      <button class="iconbtn" onclick={onClose} aria-label="Close">×</button>
-    </div>
-    <div class="modal-body">
-      {@render children()}
-    </div>
+<dialog
+  bind:this={dialogEl}
+  class="modal-panel"
+  aria-label={title}
+  onclick={onBackdropClick}
+  onclose={onClose}
+  transition:fly={{ y: 18, duration: 220 }}
+>
+  <div class="modal-head">
+    <span class="mt">{title}{#if meta}<span class="mm">{meta}</span>{/if}</span>
+    <button class="iconbtn" onclick={requestClose} aria-label="Close">×</button>
   </div>
-</div>
+  <div class="modal-body">
+    {@render children()}
+  </div>
+</dialog>


### PR DESCRIPTION
## Summary
- `Modal.svelte` and `IntegrationForm.svelte` now use native `<dialog>` + `showModal()` instead of hand-rolled overlay divs — gets initial focus, focus containment (Tab can't escape to the background), Escape-to-close, and an inert background for free, no custom JS.
- Every close path (Cancel button, × button, backdrop click) routes through the dialog's own `.close()` so the browser's native focus-restore-to-trigger runs before the component unmounts.
- `Settings.svelte`: removed the desktop-only CSS rule that hid the Move up/down buttons in favor of mouse-only drag reordering — those buttons were already keyboard-operable, they just had no keyboard path on desktop viewports.

This covers labby audit task 2/5 (accessibility/keyboard rebuild) from the honest UI/UX audit.

## Test plan
- [x] `bun test` — 182/182 pass, including 3 new Playwright e2e tests: focus trap + Escape + focus-return (Customize dialog), focus trap + backdrop-click + focus-return (Integration dialog), keyboard-driven reorder on a fine-pointer viewport
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [x] Manually drove the app in a real browser (Playwright script) to confirm focus trap, Escape close, backdrop click close, and focus return all work correctly before writing the automated tests