### PR TITLE
fix: correct UI data semantics (CSS cancel, health scope, counts, max)

### DIFF
--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -293,3 +293,130 @@ e2e('Service reordering is keyboard-reachable on a desktop (fine pointer) viewpo
 
   await page.close();
 }, 30_000);
+
+e2e('Docker widget counts only running containers as "Running"', async () => {
+  const createRes = await fetch(`${BASE}/api/integrations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Docker E2E',
+      type: 'docker',
+      enabled: true,
+      refreshSeconds: 300,
+      config: { show: 'all' },
+    }),
+  });
+  const { id } = (await createRes.json()) as { id: number };
+
+  const page = await browser.newPage();
+  try {
+    const containers = [
+      { id: 'a', name: 'up-1', image: 'x', state: 'running', status: 'Up', cpuPercent: 1 },
+      { id: 'b', name: 'up-2', image: 'x', state: 'running', status: 'Up', cpuPercent: 1 },
+      { id: 'c', name: 'down-1', image: 'x', state: 'exited', status: 'Exited', cpuPercent: null },
+    ];
+    await page.route(`**/api/integrations/${id}/data`, async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ containers }),
+      });
+    });
+
+    await page.goto(BASE, { waitUntil: 'load' });
+    const card = page.getByRole('button', { name: /Docker E2E/ });
+    await card.waitFor({ state: 'visible', timeout: 10_000 });
+    const gaugeValue = await card.locator('.gauge .v').first().textContent();
+    expect(gaugeValue?.trim()).toBe('2');
+
+    await card.click();
+    const dialog = page.locator('dialog[open]');
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+    const meta = await dialog.locator('.mm').textContent();
+    expect(meta?.trim()).toBe('2/3 running');
+  } finally {
+    await page.close();
+    await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
+  }
+}, 30_000);
+
+e2e('Canceling the Customize dialog discards the unsaved custom CSS preview', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const draftCss = 'body { background: rgb(1, 2, 3) !important; }';
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  await page.locator('dialog[open]').waitFor({ state: 'visible', timeout: 5_000 });
+  await page.locator('#settings-css').fill(draftCss);
+
+  const liveWhileOpen = await page.evaluate(
+    () => document.getElementById('labby-custom-css-dynamic')?.textContent ?? '',
+  );
+  expect(liveWhileOpen).toContain('rgb(1, 2, 3)');
+
+  await page.keyboard.press('Escape');
+  await page.locator('dialog[open]').waitFor({ state: 'detached', timeout: 5_000 });
+
+  const liveAfterCancel = await page.evaluate(
+    () => document.getElementById('labby-custom-css-dynamic')?.textContent ?? '',
+  );
+  expect(liveAfterCancel).not.toContain('rgb(1, 2, 3)');
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  await page.locator('dialog[open]').waitFor({ state: 'visible', timeout: 5_000 });
+  expect(await page.locator('#settings-css').inputValue()).not.toContain('rgb(1, 2, 3)');
+
+  await page.close();
+}, 30_000);
+
+e2e('Downloads modal caps the list at the configured max and reports what is hidden', async () => {
+  const createRes = await fetch(`${BASE}/api/integrations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Downloads E2E',
+      type: 'qbittorrent',
+      enabled: true,
+      refreshSeconds: 300,
+      config: { max: 2 },
+    }),
+  });
+  const { id } = (await createRes.json()) as { id: number };
+
+  const page = await browser.newPage();
+  try {
+    const torrents = Array.from({ length: 5 }, (_, i) => ({
+      name: `torrent-${i}`,
+      progress: 50,
+      dlSpeed: 0,
+      upSpeed: 0,
+      state: 'downloading',
+      hash: `hash-${i}`,
+    }));
+    await page.route(`**/api/integrations/${id}/data`, async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ torrents, aggregateDlSpeed: 0, aggregateUpSpeed: 0 }),
+      });
+    });
+
+    await page.goto(BASE, { waitUntil: 'load' });
+    const card = page.getByRole('button', { name: /Downloads E2E/ });
+    await card.waitFor({ state: 'visible', timeout: 10_000 });
+    await card.click();
+
+    const dialog = page.locator('dialog[open]');
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+    const rows = dialog.locator('.tor');
+    await rows.first().waitFor({ state: 'visible', timeout: 5_000 });
+    expect(await rows.count()).toBe(2);
+    await dialog
+      .getByText('+3 more not shown')
+      .waitFor({ state: 'visible', timeout: 5_000 });
+  } finally {
+    await page.close();
+    await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
+  }
+}, 30_000);

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -32,6 +32,9 @@ try {
   hasBrowser = false;
 }
 const e2e = hasBrowser ? test : test.skip;
+// Tests that create/delete integrations must never run against a live target
+// (LABBY_E2E_URL) — that would mutate its config and restart its scheduler.
+const e2eLocalOnly = hasBrowser && !EXTERNAL ? test : test.skip;
 
 let server: ReturnType<typeof Bun.spawn> | null = null;
 let browser: Browser;
@@ -294,7 +297,7 @@ e2e('Service reordering is keyboard-reachable on a desktop (fine pointer) viewpo
   await page.close();
 }, 30_000);
 
-e2e('Docker widget counts only running containers as "Running"', async () => {
+e2eLocalOnly('Docker widget counts only running containers as "Running"', async () => {
   const createRes = await fetch(`${BASE}/api/integrations`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -370,7 +373,7 @@ e2e('Canceling the Customize dialog discards the unsaved custom CSS preview', as
   await page.close();
 }, 30_000);
 
-e2e('Downloads modal caps the list at the configured max and reports what is hidden', async () => {
+e2eLocalOnly('Downloads modal caps the list at the configured max and reports what is hidden', async () => {
   const createRes = await fetch(`${BASE}/api/integrations`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -132,13 +132,11 @@
 
   function previewDensity(next: 'default' | 'compact') {
     density = next;
-    config.theme.density = next;
     document.documentElement.dataset.density = next;
   }
 
   function previewCss(next: string) {
     customCss = next;
-    config.theme.customCss = next;
   }
 
   async function quickSetTheme(next: string) {
@@ -181,8 +179,6 @@
       document.documentElement.dataset.theme = originalTheme;
     }
     theme = originalTheme;
-    config.theme.density = config.theme?.density ?? 'default';
-    config.theme.customCss = config.theme?.customCss ?? '';
     density = config.theme?.density ?? 'default';
     document.documentElement.dataset.density = density;
     customCss = config.theme?.customCss ?? '';
@@ -250,11 +246,13 @@
       <span class="header-time">{currentTime}</span>
     {/if}
 
-    <div class="summary">
-      <span class="chip" title="Services up"><span class="dot ok"></span><b>{summary.up}</b></span>
-      <span class="chip" title="Warnings"><span class="dot warn"></span><b>{summary.warn}</b></span>
-      <span class="chip" title="Services down"><span class="dot down"></span><b>{summary.down}</b></span>
-    </div>
+    {#if monitorIds.length > 0}
+      <div class="summary">
+        <span class="chip" title="Monitored sites up"><span class="dot ok"></span><b>{summary.up}</b></span>
+        <span class="chip" title="Monitored sites warning"><span class="dot warn"></span><b>{summary.warn}</b></span>
+        <span class="chip" title="Monitored sites down"><span class="dot down"></span><b>{summary.down}</b></span>
+      </div>
+    {/if}
 
     <span class="quick-theme">
       <Select value={theme} options={themes} onchange={quickSetTheme} pill={true} style="width: 170px;" />

--- a/src/web/src/widgets/Docker.svelte
+++ b/src/web/src/widgets/Docker.svelte
@@ -9,7 +9,7 @@
   const store = $derived(getStore(integrationId));
   const state = $derived($store as WidgetState<DockerData>);
   const all = $derived(state.data?.containers ?? []);
-  const total = $derived(all.length);
+  const running = $derived(all.filter((c) => c.state === 'running').length);
   const avgCpu = $derived.by(() => {
     const v = all.map((c) => c.cpuPercent).filter((c): c is number => c != null);
     return v.length ? Math.round(v.reduce((a, b) => a + b, 0) / v.length) : 0;
@@ -72,7 +72,7 @@
     <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
   {:else}
     <div class="gauges">
-      <div class="gauge"><div class="v">{total}</div><div class="k">Running</div></div>
+      <div class="gauge"><div class="v">{running}</div><div class="k">Running</div></div>
       <div class="gauge"><div class="v accent">{avgCpu}%</div><div class="k">Avg CPU</div></div>
     </div>
     <div class="card-cta">View containers →</div>
@@ -80,7 +80,7 @@
 </button>
 
 {#if listOpen}
-  <Modal title="Containers" meta={`${total} running`} onClose={() => (listOpen = false)}>
+  <Modal title="Containers" meta={`${running}/${all.length} running`} onClose={() => (listOpen = false)}>
     {#if containers.length === 0}
       <p class="state-msg">No containers</p>
     {/if}

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -16,7 +16,8 @@
   const icon = $derived(client === 'qbittorrent' ? 'di:qbittorrent' : 'di:transmission');
   const allTorrents = $derived(state.data?.torrents ?? []);
   const counts = $derived(prepareDownloads(allTorrents, 0));
-  const list = $derived(prepareDownloads(allTorrents, allTorrents.length).visible);
+  const capped = $derived(prepareDownloads(allTorrents, max && max > 0 ? max : 8));
+  const list = $derived(capped.visible);
 
   let listOpen = $state(false);
   let pending = $state<Record<string, boolean>>({});
@@ -122,6 +123,9 @@
         </div>
       {/each}
     </div>
+    {#if capped.hidden > 0}
+      <p class="state-msg">+{capped.hidden} more not shown — raise Max items to see them</p>
+    {/if}
   </Modal>
 {/if}
 


### PR DESCRIPTION
## Summary
Labby audit task 3/5 — 4 data-integrity/honesty bugs found during the UI/UX audit:

- **Custom CSS cancel didn't discard the draft.** `previewDensity()`/`previewCss()` mutated the shared `config.theme.density`/`customCss` object directly on every keystroke (not just local preview state), so by the time Cancel ran there was no original value left to restore — it was just reassigning fields to themselves. Preview now only touches local component state; Cancel correctly reverts to the last-saved value.
- **Header health chips claimed to be all-services but were monitor-only.** "Services up/warn/down" only ever aggregated `monitor`-type integrations. Relabeled to "Monitored sites ..." and the row hides entirely when no monitor integration is enabled, instead of showing a misleading `0/0/0`.
- **Docker widget mislabeled stopped containers as "Running".** When an integration is configured with `show: all`, the container list includes exited containers, but the gauge/modal counted `all.length` and called it "Running" regardless of actual state. Now counts only `state === 'running'`, and the modal shows `N/M running`.
- **Downloads "Max items" field was silently ignored.** The capped list was computed as `prepareDownloads(all, all.length)` — capping at the list's own length is not a cap. Now respects the configured `max` (default 8, matching Sabnzbd's existing convention) and surfaces the previously-computed-but-never-displayed `hidden` count in the modal.

## Test plan
- [x] `bun test` — 185/185 pass, including 3 new Playwright e2e regressions: Customize-dialog cancel discards the CSS draft, Docker widget counts only running containers, Downloads modal caps at `max` and reports the hidden count
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds