### PR TITLE
feat: simplify the visual system and reduce delivery cost

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+name: Publish docs to samlo.cloud
 
 on:
   push:
@@ -10,50 +10,35 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 permissions:
   contents: read
-  pages: write
-  id-token: write
+
+concurrency:
+  group: docs-publish
+  cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build VitePress
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
       - name: Build docs
         env:
-          VITEPRESS_BASE: /${{ github.event.repository.name }}/
+          VITEPRESS_BASE: /labby/
         run: bun run docs:build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs/.vitepress/dist
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Push built docs to samlo-cloud
+        env:
+          TOKEN: ${{ secrets.SAMLO_CLOUD_DOCS_TOKEN }}
+        run: |
+          git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/samuelloranger/samlo-cloud.git" out
+          rm -rf out/docs/labby
+          mkdir -p out/docs/labby
+          cp -r docs/.vitepress/dist/. out/docs/labby/
+          cd out
+          git config user.name  "docs-bot"
+          git config user.email "docs-bot@samlo.cloud"
+          git add docs/labby
+          git diff --cached --quiet || git commit -m "docs(labby): sync ${GITHUB_SHA::7}"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ playwright/.cache/
 # Local tooling
 .codegraph/
 docs/superpowers/
+.superpowers/
 
 # Local settings database (holds service credentials — never commit)
 config/*.db

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://github.com/samuelloranger/labby/releases"><img src="https://img.shields.io/github/v/release/samuelloranger/labby" alt="Latest release" /></a>
   <a href="https://github.com/samuelloranger/labby/actions/workflows/docker.yml"><img src="https://github.com/samuelloranger/labby/actions/workflows/docker.yml/badge.svg" alt="Docker build" /></a>
   <a href="https://github.com/samuelloranger/labby/pkgs/container/labby"><img src="https://img.shields.io/badge/ghcr.io-labby-2496ED?logo=docker&logoColor=white" alt="Container image" /></a>
+  <a href="https://buymeacoffee.com/samlo122"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy me a coffee" /></a>
 </p>
 
 ![Dashboard Screenshot](docs/screenshot-v1.3.0.png)
@@ -268,6 +269,10 @@ For frontend work, run **both** dev servers. `bun run dev` alone does not serve 
 - **Backend** — Hono (JSON API, static SPA, SSE)
 - **Frontend** — Svelte 5, Vite
 - **Config** — SQLite (`bun:sqlite`), Zod validation, automatically seeded via migrations
+
+## Support
+
+If Labby is useful to you, consider [buying me a coffee](https://buymeacoffee.com/samlo122) ☕ — it keeps the project going.
 
 ## License
 

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -516,3 +516,32 @@ e2e('Canceling the Customize dialog discards an unsaved mode/palette change', as
   expect(config.theme.default).toBe('system');
   await page.close();
 }, 30_000);
+
+e2e('Decorative motion is off by default and toggling it updates data-motion and persists', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const initialMotion = await page.evaluate(() => document.documentElement.dataset.motion);
+  expect(initialMotion).not.toBe('on');
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+  await dialog.getByRole('checkbox', { name: 'Decorative motion' }).check();
+  expect(await page.evaluate(() => document.documentElement.dataset.motion)).toBe('on');
+
+  await dialog.getByRole('button', { name: 'Save' }).click();
+  await page.waitForTimeout(200);
+
+  const res = await fetch(`${BASE}/api/config`);
+  const config = (await res.json()) as { theme: { motion: boolean } };
+  expect(config.theme.motion).toBe(true);
+
+  await fetch(`${BASE}/api/theme`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ motion: false }),
+  });
+  await page.close();
+}, 30_000);

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -434,3 +434,85 @@ e2e('first-paint resolver applies a stored system-<palette> preference before an
   expect(dataTheme).toBe('dark-nord');
   await page.close();
 }, 30_000);
+
+e2e('Customize dialog mode + palette controls compose correctly and persist', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+  // Scope the palette control to the dialog — the header pill renders its own
+  // "Palette selector" combobox too, and both are visible at the same time.
+  await dialog.getByRole('radio', { name: 'Dark' }).check();
+  await dialog.getByLabel('Palette selector').click();
+  await page.getByRole('option', { name: 'Nord' }).click();
+
+  const dataTheme = await page.evaluate(() => document.documentElement.dataset.theme);
+  expect(dataTheme).toBe('dark-nord');
+
+  await dialog.getByRole('button', { name: 'Save' }).click();
+  await page.waitForTimeout(200);
+
+  const res = await fetch(`${BASE}/api/config`);
+  const config = (await res.json()) as { theme: { default: string } };
+  expect(config.theme.default).toBe('dark-nord');
+
+  // reset to system/amber so later tests see the default state
+  await fetch(`${BASE}/api/theme`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme: 'system' }),
+  });
+  await page.close();
+}, 30_000);
+
+e2e('System mode composes with the selected palette', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+  await dialog.getByRole('radio', { name: 'System' }).check();
+  await dialog.getByLabel('Palette selector').click();
+  await page.getByRole('option', { name: 'Forest' }).click();
+  await dialog.getByRole('button', { name: 'Save' }).click();
+  await page.waitForTimeout(200);
+
+  const res = await fetch(`${BASE}/api/config`);
+  const config = (await res.json()) as { theme: { default: string } };
+  expect(config.theme.default).toBe('system-forest');
+
+  await fetch(`${BASE}/api/theme`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme: 'system' }),
+  });
+  await page.close();
+}, 30_000);
+
+e2e('Canceling the Customize dialog discards an unsaved mode/palette change', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  await page.getByRole('button', { name: 'Customize interface' }).click();
+  const dialog = page.locator('dialog[open]');
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+  await dialog.getByRole('radio', { name: 'Dark' }).check();
+  await dialog.getByLabel('Palette selector').click();
+  await page.getByRole('option', { name: 'Ocean' }).click();
+
+  await page.keyboard.press('Escape');
+  await dialog.waitFor({ state: 'detached', timeout: 5_000 });
+
+  const res = await fetch(`${BASE}/api/config`);
+  const config = (await res.json()) as { theme: { default: string } };
+  expect(config.theme.default).toBe('system');
+  await page.close();
+}, 30_000);

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -423,3 +423,14 @@ e2eLocalOnly('Downloads modal caps the list at the configured max and reports wh
     await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
   }
 }, 30_000);
+
+e2e('first-paint resolver applies a stored system-<palette> preference before any JS module runs', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.evaluate(() => localStorage.setItem('labby-theme', 'system-nord'));
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.reload({ waitUntil: 'commit' });
+  const dataTheme = await page.evaluate(() => document.documentElement.dataset.theme);
+  expect(dataTheme).toBe('dark-nord');
+  await page.close();
+}, 30_000);

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import { app } from './app';
-import { loadConfig } from './config/loader';
+import { getConfig, loadConfig } from './config/loader';
 import { createIntegration, deleteIntegration, listIntegrations } from './db';
 
 const TEST_NAME = '__test_app_routes__';
@@ -35,6 +35,26 @@ test('POST /api/theme validates and saves theme settings', async () => {
   });
   expect(ok.status).toBe(200);
   expect(await ok.json()).toEqual({ ok: true });
+});
+
+test('POST /api/theme persists motion alongside the other fields', async () => {
+  await loadConfig();
+  const res = await app.request('/api/theme', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme: 'system-nord', motion: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(getConfig()?.theme.default).toBe('system-nord');
+  expect(getConfig()?.theme.motion).toBe(true);
+
+  const reset = await app.request('/api/theme', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme: 'system', motion: false }),
+  });
+  expect(reset.status).toBe(200);
+  expect(getConfig()?.theme.motion).toBe(false);
 });
 
 test('GET /api/integrations/:id/data returns 404 for missing row', async () => {

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -57,6 +57,26 @@ test('POST /api/theme persists motion alongside the other fields', async () => {
   expect(getConfig()?.theme.motion).toBe(false);
 });
 
+test('GET /api/integrations/types is gzip-compressed when requested', async () => {
+  // Chosen over /api/config: /api/config's default-seed response is ~85 bytes,
+  // well under compress()'s 1024-byte default threshold, so it would never
+  // compress regardless of whether the middleware works. /api/integrations/types
+  // is a stable ~3.8KB response independent of DB seed state.
+  const res = await app.request('/api/integrations/types', {
+    headers: { 'Accept-Encoding': 'gzip' },
+  });
+  expect(res.status).toBe(200);
+  expect(res.headers.get('Content-Encoding')).toBe('gzip');
+});
+
+test('GET /api/stream is never compressed, even when requested', async () => {
+  const res = await app.request('/api/stream', {
+    headers: { 'Accept-Encoding': 'gzip' },
+  });
+  expect(res.headers.get('Content-Encoding')).toBeNull();
+  res.body?.cancel();
+});
+
 test('GET /api/integrations/:id/data returns 404 for missing row', async () => {
   const res = await app.request('/api/integrations/999999/data');
   expect(res.status).toBe(404);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -234,6 +234,7 @@ app.post('/api/theme', async (c) => {
     layout?: string;
     density?: string;
     customCss?: string;
+    motion?: boolean;
   }>();
   const updates: Parameters<typeof saveThemeSettings>[0] = {};
 
@@ -260,6 +261,12 @@ app.post('/api/theme', async (c) => {
   }
   if (body.customCss !== undefined) {
     updates.customCss = body.customCss;
+  }
+  if (body.motion !== undefined) {
+    if (typeof body.motion !== 'boolean') {
+      return c.json({ error: 'Invalid motion' }, 400);
+    }
+    updates.motion = body.motion;
   }
 
   await saveThemeSettings(updates);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { type Context, Hono } from 'hono';
+import { compress } from 'hono/compress';
 import { streamSSE } from 'hono/streaming';
 import { z } from 'zod';
 import { getConfig, getConfigState, reloadConfig, saveThemeSettings } from './config/loader';
@@ -35,6 +36,7 @@ import { hub } from './sse/hub';
 import { refreshIntegration, startScheduler } from './sse/scheduler';
 
 const app = new Hono();
+app.use(compress());
 
 const WEB_DIST = path.join(process.cwd(), 'src', 'web', 'dist');
 const INDEX_PATH = path.join(WEB_DIST, 'index.html');

--- a/src/server/config/loader.ts
+++ b/src/server/config/loader.ts
@@ -59,6 +59,7 @@ export async function saveThemeSettings(settings: {
   layout?: LayoutType;
   density?: DensityType;
   customCss?: string;
+  motion?: boolean;
 }): Promise<void> {
   const raw = await readConfigRaw();
   const parsed = JSON.parse(raw) as Record<string, unknown>;
@@ -69,6 +70,7 @@ export async function saveThemeSettings(settings: {
     ...(settings.layout ? { layout: settings.layout } : {}),
     ...(settings.density ? { density: settings.density } : {}),
     ...(settings.customCss !== undefined ? { customCss: settings.customCss } : {}),
+    ...(settings.motion !== undefined ? { motion: settings.motion } : {}),
   };
   const config = DashboardSchema.parse(parsed);
   setSetting('dashboard', JSON.stringify(parsed, null, 2));

--- a/src/server/config/schema.test.ts
+++ b/src/server/config/schema.test.ts
@@ -39,4 +39,37 @@ describe('DashboardSchema', () => {
     });
     expect((parsed as any).pages).toBeUndefined();
   });
+
+  test('parses every system-<palette> theme value', () => {
+    const palettes = [
+      'slate',
+      'mint',
+      'rose',
+      'nord',
+      'peach',
+      'graphite',
+      'ocean',
+      'forest',
+      'dracula',
+      'cyberpunk',
+    ];
+    for (const p of palettes) {
+      const config = DashboardSchema.parse({
+        title: 'Labby',
+        theme: { default: `system-${p}` as any },
+      });
+      expect(config.theme.default).toBe(`system-${p}` as any);
+    }
+  });
+
+  test('theme.motion defaults to false and accepts true', () => {
+    const defaulted = DashboardSchema.parse({ title: 'Labby' });
+    expect(defaulted.theme.motion).toBe(false);
+
+    const enabled = DashboardSchema.parse({
+      title: 'Labby',
+      theme: { default: 'system', motion: true },
+    });
+    expect(enabled.theme.motion).toBe(true);
+  });
 });

--- a/src/server/config/schema.ts
+++ b/src/server/config/schema.ts
@@ -24,6 +24,16 @@ export const ThemeSchema = z.enum([
   'light-forest',
   'light-dracula',
   'light-cyberpunk',
+  'system-slate',
+  'system-mint',
+  'system-rose',
+  'system-nord',
+  'system-peach',
+  'system-graphite',
+  'system-ocean',
+  'system-forest',
+  'system-dracula',
+  'system-cyberpunk',
 ]);
 export type ThemeName = z.infer<typeof ThemeSchema>;
 
@@ -38,6 +48,7 @@ export const ThemeConfigSchema = z.object({
   layout: LayoutSchema.default('masonry'),
   density: DensitySchema.default('compact'),
   customCss: z.string().optional(),
+  motion: z.boolean().default(false),
 });
 export type ThemeConfig = z.infer<typeof ThemeConfigSchema>;
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -3,7 +3,8 @@
 <head>
 <script>(()=> {var a=["light","light-slate","light-mint","light-rose","light-nord","light-peach","dark","dark-graphite","dark-ocean","dark-forest","dark-dracula","dark-nord","dark-cyberpunk","dark-slate","dark-mint","dark-rose","dark-peach","light-graphite","light-ocean","light-forest","light-dracula","light-cyberpunk"],s="__LABBY_THEME__",t;try{t=localStorage.getItem("labby-theme")}catch(_e){}
 var sys=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";
-document.documentElement.dataset.theme=a.includes(s)?s:(a.includes(t)?t:sys);
+function r(v){var c;if(a.indexOf(v)>-1)return v;if(v==="system")return sys;if(typeof v==="string"&&v.indexOf("system-")===0){c=sys+v.slice(6);if(a.indexOf(c)>-1)return c}return null}
+document.documentElement.dataset.theme=r(s)||r(t)||sys;
 var d;try{d=localStorage.getItem("labby-density")}catch(_e){}
 document.documentElement.dataset.density=d==="compact"?"compact":"default";
 })();</script>

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -2167,12 +2167,14 @@ header.top {
   transform: scale(0.93);
 }
 
-/* header logo: idle float, spin on hover */
+/* header logo: idle float (opt-in via data-motion), spin on hover */
 .brand .logo {
-  animation: float 4s ease-in-out infinite;
   transition:
     transform 0.4s var(--ease),
     filter 0.3s var(--ease);
+}
+:root[data-motion="on"] .brand .logo {
+  animation: float 4s ease-in-out infinite;
 }
 .brand:hover .logo {
   transform: rotate(360deg) scale(1.12);
@@ -2209,8 +2211,8 @@ header.top {
   }
 }
 
-/* state messages breathe so empty/loading feels alive */
-.state-msg {
+/* state messages breathe so empty/loading feels alive (opt-in via data-motion) */
+:root[data-motion="on"] .state-msg {
   animation: breathe 2.4s var(--ease) infinite;
 }
 

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -1,43 +1,28 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { Settings, Database } from 'lucide-svelte';
+  import { Monitor, Moon, Settings, Database, Sun } from 'lucide-svelte';
   import Modal from './Modal.svelte';
   import Select from './Select.svelte';
   import { get } from 'svelte/store';
   import { getStore, streamConnected, type MonitorData, type WidgetState } from '$lib/stores';
   import type { Dashboard, IntegrationRow } from '$lib/types';
-
-  const themes = [
-    ['system', 'System Default'],
-    ['light', 'Light (Amber)'],
-    ['light-slate', 'Slate (Light)'],
-    ['light-mint', 'Mint (Light)'],
-    ['light-rose', 'Rose (Light)'],
-    ['light-nord', 'Nord (Light)'],
-    ['light-peach', 'Peach (Light)'],
-    ['light-graphite', 'Graphite (Light)'],
-    ['light-ocean', 'Ocean (Light)'],
-    ['light-forest', 'Forest (Light)'],
-    ['light-dracula', 'Dracula (Light)'],
-    ['light-cyberpunk', 'Cyberpunk (Light)'],
-    ['dark', 'Dark (Amber)'],
-    ['dark-graphite', 'Graphite (Dark)'],
-    ['dark-ocean', 'Ocean (Dark)'],
-    ['dark-forest', 'Forest (Dark)'],
-    ['dark-dracula', 'Dracula (Dark)'],
-    ['dark-nord', 'Nord (Dark)'],
-    ['dark-cyberpunk', 'Cyberpunk (Dark)'],
-    ['dark-slate', 'Slate (Dark)'],
-    ['dark-mint', 'Mint (Dark)'],
-    ['dark-rose', 'Rose (Dark)'],
-    ['dark-peach', 'Peach (Dark)'],
-  ] as const;
+  import {
+    composeTheme,
+    decomposeTheme,
+    PALETTES,
+    resolveConcreteTheme,
+    type Mode,
+    type Palette,
+  } from '$lib/theme';
 
   let { config, integrations = [] }: { config: Dashboard; integrations?: IntegrationRow[] } = $props();
   const title = $derived(config.title ?? 'Labby');
 
-  let theme = $state(config.theme?.default ?? 'system');
+  const initial = decomposeTheme(config.theme?.default ?? 'system');
+  let mode = $state<Mode>(initial.mode);
+  let palette = $state<Palette>(initial.palette);
   let density = $state<'default' | 'compact'>('compact');
+  let motion = $state(config.theme?.motion ?? false);
   let customCss = $state(config.theme?.customCss ?? '');
   let settingsOpen = $state(false);
   let saving = $state(false);
@@ -73,6 +58,10 @@
 
   const connectedVal = $derived($streamConnected);
 
+  function systemIsDark(): boolean {
+    return matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
   onMount(() => {
     // Remove server-injected custom css tag since Svelte will handle it
     const serverStyle = document.getElementById('labby-custom-css');
@@ -82,11 +71,9 @@
 
     try {
       const stored = localStorage.getItem('labby-theme');
-      if (stored) {
-        theme = stored as any;
-      } else {
-        theme = config.theme?.default ?? 'system';
-      }
+      const decomposed = decomposeTheme(stored ?? config.theme?.default ?? 'system');
+      mode = decomposed.mode;
+      palette = decomposed.palette;
     } catch {}
 
     try {
@@ -98,6 +85,8 @@
       }
       document.documentElement.dataset.density = density;
     } catch {}
+
+    document.documentElement.dataset.motion = motion ? 'on' : 'off';
 
     const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     const mon = [
@@ -120,14 +109,20 @@
     }
   }
 
-  function previewTheme(next: string) {
-    theme = next as any;
-    if (next === 'system') {
-      const sys = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      document.documentElement.dataset.theme = sys;
-    } else {
-      document.documentElement.dataset.theme = next;
-    }
+  const themeId = $derived(composeTheme(mode, palette));
+
+  function applyThemePreview() {
+    document.documentElement.dataset.theme = resolveConcreteTheme(mode, palette, systemIsDark());
+  }
+
+  function previewMode(next: Mode) {
+    mode = next;
+    applyThemePreview();
+  }
+
+  function previewPalette(next: Palette) {
+    palette = next;
+    applyThemePreview();
   }
 
   function previewDensity(next: 'default' | 'compact') {
@@ -135,12 +130,17 @@
     document.documentElement.dataset.density = next;
   }
 
+  function previewMotion(next: boolean) {
+    motion = next;
+    document.documentElement.dataset.motion = next ? 'on' : 'off';
+  }
+
   function previewCss(next: string) {
     customCss = next;
   }
 
-  async function quickSetTheme(next: string) {
-    previewTheme(next);
+  async function persistTheme() {
+    const next = themeId;
     try {
       const res = await fetch('/api/theme', {
         method: 'POST',
@@ -162,49 +162,63 @@
     }
   }
 
+  async function quickSetMode(next: Mode) {
+    previewMode(next);
+    await persistTheme();
+  }
+
+  async function quickSetPalette(next: Palette) {
+    previewPalette(next);
+    await persistTheme();
+  }
+
   function openSettings() {
-    theme = config.theme?.default ?? 'system';
+    const decomposed = decomposeTheme(config.theme?.default ?? 'system');
+    mode = decomposed.mode;
+    palette = decomposed.palette;
     density = config.theme?.density ?? 'default';
+    motion = config.theme?.motion ?? false;
     customCss = config.theme?.customCss ?? '';
     settingsOpen = true;
   }
 
   function closeSettings() {
     settingsOpen = false;
-    const originalTheme = config.theme?.default ?? 'system';
-    if (originalTheme === 'system') {
-      const sys = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      document.documentElement.dataset.theme = sys;
-    } else {
-      document.documentElement.dataset.theme = originalTheme;
-    }
-    theme = originalTheme;
+    const original = decomposeTheme(config.theme?.default ?? 'system');
+    mode = original.mode;
+    palette = original.palette;
+    document.documentElement.dataset.theme = resolveConcreteTheme(mode, palette, systemIsDark());
     density = config.theme?.density ?? 'default';
     document.documentElement.dataset.density = density;
+    motion = config.theme?.motion ?? false;
+    document.documentElement.dataset.motion = motion ? 'on' : 'off';
     customCss = config.theme?.customCss ?? '';
   }
 
   async function saveSettings() {
     saving = true;
     try {
+      const next = themeId;
       const res = await fetch('/api/theme', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          theme: theme,
+          theme: next,
           density: density,
+          motion: motion,
           customCss: customCss,
         }),
       });
       if (res.ok) {
-        config.theme.default = theme;
+        config.theme.default = next as any;
         config.theme.density = density;
+        config.theme.motion = motion;
         config.theme.customCss = customCss;
         try {
-          if (theme === 'system') {
+          if (next === 'system') {
             localStorage.removeItem('labby-theme');
           } else {
-            localStorage.setItem('labby-theme', theme);
+            localStorage.setItem('labby-theme', next);
           }
           localStorage.setItem('labby-density', density);
         } catch {}
@@ -255,7 +269,24 @@
     {/if}
 
     <span class="quick-theme">
-      <Select value={theme} options={themes} onchange={quickSetTheme} pill={true} style="width: 170px;" />
+      <span class="mode-toggle" role="group" aria-label="Theme mode">
+        <button type="button" class="mode-btn" class:active={mode === 'light'} onclick={() => quickSetMode('light')} aria-label="Light" aria-pressed={mode === 'light'} title="Light">
+          <Sun size={15} />
+        </button>
+        <button type="button" class="mode-btn" class:active={mode === 'dark'} onclick={() => quickSetMode('dark')} aria-label="Dark" aria-pressed={mode === 'dark'} title="Dark">
+          <Moon size={15} />
+        </button>
+        <button type="button" class="mode-btn" class:active={mode === 'system'} onclick={() => quickSetMode('system')} aria-label="System" aria-pressed={mode === 'system'} title="System">
+          <Monitor size={15} />
+        </button>
+      </span>
+      <Select
+        value={palette}
+        options={PALETTES}
+        onchange={(v) => quickSetPalette(v as Palette)}
+        pill={true}
+        style="width: 130px;"
+      />
     </span>
 
     <button class="iconbtn" onclick={() => window.location.hash = '#settings'} aria-label="Manage services" title="Manage services">
@@ -272,8 +303,26 @@
   <Modal title="Customize Dashboard" onClose={closeSettings}>
     <div class="settings-form">
       <div class="settings-group">
-        <label for="settings-theme">Theme</label>
-        <Select id="settings-theme" value={theme} options={themes} onchange={previewTheme} pill={false} style="width: 100%;" />
+        <span class="settings-label">Theme mode</span>
+        <div class="settings-radio-group" role="radiogroup" aria-label="Theme mode">
+          <label class="radio-label">
+            <input type="radio" name="theme-mode" value="light" checked={mode === 'light'} onchange={() => previewMode('light')} />
+            <span>Light</span>
+          </label>
+          <label class="radio-label">
+            <input type="radio" name="theme-mode" value="dark" checked={mode === 'dark'} onchange={() => previewMode('dark')} />
+            <span>Dark</span>
+          </label>
+          <label class="radio-label">
+            <input type="radio" name="theme-mode" value="system" checked={mode === 'system'} onchange={() => previewMode('system')} />
+            <span>System</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="settings-group">
+        <label for="settings-palette">Palette</label>
+        <Select id="settings-palette" value={palette} options={PALETTES} onchange={(v) => previewPalette(v as Palette)} pill={false} style="width: 100%;" />
       </div>
 
       <div class="settings-group">
@@ -289,6 +338,14 @@
           </label>
         </div>
         <p class="settings-help">Compact reduces padding, card margins, and list item spacing so more content fits on screen.</p>
+      </div>
+
+      <div class="settings-group">
+        <label class="radio-label">
+          <input type="checkbox" checked={motion} onchange={(e) => previewMotion(e.currentTarget.checked)} />
+          <span>Decorative motion</span>
+        </label>
+        <p class="settings-help">Adds an idle bob to the header logo and a slow pulse to empty/loading state messages. Off by default.</p>
       </div>
 
       <div class="settings-group">
@@ -312,5 +369,40 @@
     .quick-theme {
       display: none;
     }
+  }
+
+  .quick-theme {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .mode-toggle {
+    display: flex;
+    border: 1px solid var(--glass-brd);
+    border-radius: var(--pill);
+    overflow: hidden;
+  }
+
+  .mode-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    color: var(--ink-faint);
+    cursor: pointer;
+    transition: all 0.15s var(--ease);
+  }
+
+  .mode-btn:hover {
+    color: var(--ink);
+  }
+
+  .mode-btn.active {
+    background: var(--accent-soft);
+    color: var(--accent);
   }
 </style>

--- a/src/web/src/components/Select.svelte
+++ b/src/web/src/components/Select.svelte
@@ -34,31 +34,20 @@
 
   const currentLabel = $derived(items.find((i) => i.value === value)?.label ?? value);
 
-  // Curated gradient previews for themes to visual feedback before selecting
+  // Curated color previews, one per palette (mode-agnostic — a palette has the
+  // same accent hue in light and dark).
   const themeColors: Record<string, string> = {
-    'system': 'linear-gradient(135deg, #94a3b8 50%, #475569 50%)',
-    'light': '#d97706',
-    'light-slate': '#64748b',
-    'light-mint': '#10b981',
-    'light-rose': '#f43f5e',
-    'light-nord': '#88c0d0',
-    'light-peach': '#f97316',
-    'dark': '#f59e0b',
-    'dark-graphite': '#334155',
-    'dark-ocean': '#0284c7',
-    'dark-forest': '#059669',
-    'dark-dracula': '#bd93f9',
-    'dark-nord': '#4c566a',
-    'dark-cyberpunk': 'linear-gradient(135deg, #ff007f 0%, #ffd60a 100%)',
-    'dark-slate': '#60a5fa',
-    'dark-mint': '#34d399',
-    'dark-rose': '#fb7185',
-    'dark-peach': '#fb923c',
-    'light-graphite': '#65a30d',
-    'light-ocean': '#0891b2',
-    'light-forest': '#16a34a',
-    'light-dracula': '#7c3aed',
-    'light-cyberpunk': 'linear-gradient(135deg, #d6006e 0%, #0891b2 100%)',
+    amber: '#d97706',
+    slate: '#64748b',
+    mint: '#10b981',
+    rose: '#f43f5e',
+    nord: '#88c0d0',
+    peach: '#f97316',
+    graphite: '#65a30d',
+    ocean: '#0891b2',
+    forest: '#16a34a',
+    dracula: '#7c3aed',
+    cyberpunk: 'linear-gradient(135deg, #d6006e 0%, #0891b2 100%)',
   };
 
   function toggle(e: MouseEvent) {
@@ -140,7 +129,7 @@
   role="combobox"
   aria-expanded={open}
   aria-haspopup="listbox"
-  aria-label="Theme selector"
+  aria-label="Palette selector"
 >
   <div class="select-trigger">
     <span class="theme-dot" style="background: {themeColors[value] || '#888'}"></span>

--- a/src/web/src/lib/theme.test.ts
+++ b/src/web/src/lib/theme.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  composeTheme,
+  decomposeTheme,
+  isPalette,
+  PALETTES,
+  resolveConcreteTheme,
+} from './theme';
+
+describe('PALETTES', () => {
+  test('has 11 entries starting with amber', () => {
+    expect(PALETTES.length).toBe(11);
+    expect(PALETTES[0][0]).toBe('amber');
+  });
+});
+
+describe('isPalette', () => {
+  test('accepts known palette keys, rejects unknown', () => {
+    expect(isPalette('nord')).toBe(true);
+    expect(isPalette('amber')).toBe(true);
+    expect(isPalette('not-a-palette')).toBe(false);
+  });
+});
+
+describe('decomposeTheme', () => {
+  test('bare system', () => {
+    expect(decomposeTheme('system')).toEqual({ mode: 'system', palette: 'amber' });
+  });
+  test('system with a palette', () => {
+    expect(decomposeTheme('system-nord')).toEqual({ mode: 'system', palette: 'nord' });
+  });
+  test('bare light and dark are the amber palette', () => {
+    expect(decomposeTheme('light')).toEqual({ mode: 'light', palette: 'amber' });
+    expect(decomposeTheme('dark')).toEqual({ mode: 'dark', palette: 'amber' });
+  });
+  test('light/dark with a palette suffix', () => {
+    expect(decomposeTheme('light-ocean')).toEqual({ mode: 'light', palette: 'ocean' });
+    expect(decomposeTheme('dark-dracula')).toEqual({ mode: 'dark', palette: 'dracula' });
+  });
+  test('an unrecognized palette suffix falls back to amber', () => {
+    expect(decomposeTheme('dark-nonsense')).toEqual({ mode: 'dark', palette: 'amber' });
+  });
+});
+
+describe('composeTheme', () => {
+  test('round-trips every mode x palette combination through decomposeTheme', () => {
+    const modes = ['system', 'light', 'dark'] as const;
+    for (const mode of modes) {
+      for (const [palette] of PALETTES) {
+        const id = composeTheme(mode, palette as any);
+        expect(decomposeTheme(id)).toEqual({ mode, palette });
+      }
+    }
+  });
+  test('amber palette omits the suffix', () => {
+    expect(composeTheme('light', 'amber')).toBe('light');
+    expect(composeTheme('dark', 'amber')).toBe('dark');
+    expect(composeTheme('system', 'amber')).toBe('system');
+  });
+});
+
+describe('resolveConcreteTheme', () => {
+  test('system resolves to the OS preference', () => {
+    expect(resolveConcreteTheme('system', 'nord', true)).toBe('dark-nord');
+    expect(resolveConcreteTheme('system', 'nord', false)).toBe('light-nord');
+  });
+  test('explicit light/dark ignore the OS preference flag', () => {
+    expect(resolveConcreteTheme('light', 'ocean', true)).toBe('light-ocean');
+    expect(resolveConcreteTheme('dark', 'ocean', false)).toBe('dark-ocean');
+  });
+  test('amber palette produces the bare mode name', () => {
+    expect(resolveConcreteTheme('dark', 'amber', false)).toBe('dark');
+  });
+});

--- a/src/web/src/lib/theme.test.ts
+++ b/src/web/src/lib/theme.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  composeTheme,
-  decomposeTheme,
-  isPalette,
-  PALETTES,
-  resolveConcreteTheme,
-} from './theme';
+import { composeTheme, decomposeTheme, isPalette, PALETTES, resolveConcreteTheme } from './theme';
 
 describe('PALETTES', () => {
   test('has 11 entries starting with amber', () => {

--- a/src/web/src/lib/theme.ts
+++ b/src/web/src/lib/theme.ts
@@ -1,0 +1,47 @@
+export type Mode = 'system' | 'light' | 'dark';
+
+export const PALETTES = [
+  ['amber', 'Amber'],
+  ['slate', 'Slate'],
+  ['mint', 'Mint'],
+  ['rose', 'Rose'],
+  ['nord', 'Nord'],
+  ['peach', 'Peach'],
+  ['graphite', 'Graphite'],
+  ['ocean', 'Ocean'],
+  ['forest', 'Forest'],
+  ['dracula', 'Dracula'],
+  ['cyberpunk', 'Cyberpunk'],
+] as const;
+
+export type Palette = (typeof PALETTES)[number][0];
+
+const PALETTE_KEYS = new Set<string>(PALETTES.map(([key]) => key));
+
+export function isPalette(value: string): value is Palette {
+  return PALETTE_KEYS.has(value);
+}
+
+export function decomposeTheme(id: string): { mode: Mode; palette: Palette } {
+  if (id === 'system') return { mode: 'system', palette: 'amber' };
+  if (id.startsWith('system-')) {
+    const p = id.slice('system-'.length);
+    return { mode: 'system', palette: isPalette(p) ? p : 'amber' };
+  }
+  if (id === 'light' || id === 'dark') return { mode: id, palette: 'amber' };
+  const dash = id.indexOf('-');
+  if (dash === -1) return { mode: 'light', palette: 'amber' };
+  const mode: Mode = id.slice(0, dash) === 'dark' ? 'dark' : 'light';
+  const palette = id.slice(dash + 1);
+  return { mode, palette: isPalette(palette) ? palette : 'amber' };
+}
+
+export function composeTheme(mode: Mode, palette: Palette): string {
+  if (mode === 'system') return palette === 'amber' ? 'system' : `system-${palette}`;
+  return palette === 'amber' ? mode : `${mode}-${palette}`;
+}
+
+export function resolveConcreteTheme(mode: Mode, palette: Palette, systemIsDark: boolean): string {
+  const resolvedMode = mode === 'system' ? (systemIsDark ? 'dark' : 'light') : mode;
+  return palette === 'amber' ? resolvedMode : `${resolvedMode}-${palette}`;
+}


### PR DESCRIPTION
Implements board task #176 — simplify the visual system and reduce delivery cost.

## What changed

**Theme picker: 23-item flat dropdown → mode toggle + palette dropdown**
- New pure helpers in `src/web/src/lib/theme.ts` (`composeTheme` / `decomposeTheme` / `resolveConcreteTheme`), 12 unit tests.
- `ThemeSchema` gains 10 `system-<palette>` values (additive, no migration needed). System mode now composes with any palette — it was Amber-only before.
- `Header.svelte` renders a Light/Dark/System toggle plus an 11-item palette `Select`, in both the header pill and the Customize dialog. `Select.svelte`'s color map went from 24 theme ids to 11 palette keys.
- `index.html`'s first-paint resolver decomposes `system-<palette>` before paint, so there's still zero flash.

**Decorative motion is opt-in, off by default**
- Logo idle-float and state-message breathe are gated behind `:root[data-motion="on"]`.
- The reconnecting pulse and live-activity dots stay unconditional — they're functional feedback, not decoration.
- `theme.motion` boolean persists through `saveThemeSettings` and `POST /api/theme`.

**Response compression**
- `hono/compress` middleware, no new dependency. SSE `/api/stream` is excluded automatically (Hono's default content-type regex skips `text/event-stream`), verified by test and by curl.
- Measured: JS 271,913 → 61,001 bytes (78% smaller), CSS 66,634 → 12,265 bytes (82% smaller).

Two unrelated docs/CI commits ride along on this branch: the Buy Me a Coffee badge and the docs publish target moving to samlo.cloud.

## Deferred

Typography and spacing token consolidation is **not** in this PR. Deferred by decision during brainstorming — high visual-regression risk across 24 themes with no automated visual-diff tooling. Tracked as follow-up.

## Verification

- `bun test` — 207 pass, 0 fail
- `bun run lint` — clean
- typecheck and build — clean
- Manual Playwright spot-check across Dark+Nord, Light+Forest, System+Cyberpunk: header pill and dialog stay in sync, no page errors, no visual regression in screenshots
