### PR TITLE
fix: accessibility, contrast, responsive and motion — audit 14/20 → 19/20

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,89 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Self-hosters running services on a homelab, viewing Labby over their own LAN or VPN. Confirmed usage scenes, all three load-bearing:
+
+- **Desktop browser tab** — open alongside other work, mouse and keyboard primary, density matters.
+- **Browser homepage / new tab** — seen dozens of times a day in short bursts. First-paint speed and instant scanability dominate; this is why the zero-flash theme resolver exists.
+- **Phone, checking in** — quick glance or a control action (stop a container, pause a torrent) from a phone on the LAN/VPN. Thumb-driven, so the mobile layout and touch target sizes are real requirements, not afterthoughts.
+
+Wall/kiosk display is *not* a target scene.
+
+Labby is a public open-source project (MIT, GHCR image, appeared in selfh.st Self-Host Weekly), so the audience is other self-hosters, not one operator.
+
+## Product Purpose
+
+A single-container homelab dashboard that shows live service status and lets the user act on it without leaving the page. Success is the user glancing at one tab and knowing everything is fine — or fixing it in one click when it isn't.
+
+## Positioning
+
+"Lightweight like Glance, interactive like Homarr." The differentiator is holding both at once: one Bun process and one container with no external dependencies, while still supporting write actions against integrated services (start/stop containers, pause/resume torrents, toggle AdGuard protection).
+
+Second differentiator: **the browser never polls.** The server polls each integration on its own interval and pushes over SSE, with the latest payload cached per stream so a new tab fills instantly on connect.
+
+## Operating Context
+
+- Deployed as `ghcr.io/samuelloranger/labby`, one container, one mounted `config/` volume.
+- Runs behind a reverse proxy restricted to LAN or VPN. **There is no authentication** — anyone who can reach the app can read status and control every integrated service. This is a deliberate design decision, documented in the README.
+- Configured entirely in-app on the Manage Services page; no config file to hand-edit.
+- Config and service credentials live in SQLite at `config/labby.db`. `config/` must be writable by the container's uid or writes fail with `SQLITE_READONLY`.
+- Backups are written server-side to `config/backups/` in plaintext including credentials, and are never returned in an API response.
+
+## Capabilities and Constraints
+
+**Confirmed functionality**
+- 18+ integration types: service monitor, Docker, qBittorrent, Transmission, SABnzbd, AdGuard, Jellyfin, Emby, Plex, Beszel, Radarr, Sonarr, Rawkoon, weather, calendar, speedtest, bookmarks, Reddit, Hacker News.
+- Write actions: container start/stop/restart, torrent pause/resume, AdGuard protection toggle. Each forces an immediate refresh and broadcast rather than waiting for the next tick.
+- Theming: 11 palettes × light/dark/system, persisted to the DB, resolved before first paint so there is no flash.
+
+**Technical constraints**
+- One Bun process serving a JSON API, a Svelte 5 SPA, and an SSE stream. No separate frontend server in production.
+- Server and web are separate build roots with separate tsconfigs; payload types are duplicated by design between `src/server/types.ts` and `src/web/src/lib/stores.ts`.
+- All service credentials stay server-side; the browser only ever receives sanitized data.
+- Integrations must fail soft — each returns `Payload | { error }` and never throws to the route. One dead integration must never blank the board.
+
+**Terminology**
+- An **integration** is a configured row in the DB (`id`, `type`, `config`, `enabled`, `refreshSeconds`, `position`) — it is the unit of everything: SSE event name, hub cache key, store key, scheduler timer all key off `int:${id}`.
+- A **widget** is the Svelte component that renders one integration.
+- `Channel` in `src/server/types.ts` is a legacy payload-shape alias, not a routing contract.
+
+## Brand Commitments
+
+Name **Labby** and the existing logo (`src/web/public/icons/labby.svg`) are fixed.
+
+The current visual world — glass / `backdrop-filter`, warm amber default palette — is **not** binding. The user's position: *look is negotiable, function isn't.* What must be preserved is the widget set, SSE liveness, and the zero-config single-container story. A future visual direction may replace the glass-and-amber language if there is a reason.
+
+## Evidence on Hand
+
+- Real screenshot at `docs/screenshot-v1.3.0.png` (README hero).
+- Real GitHub signals: MIT license, tagged releases, Docker build workflow, GHCR package, Buy Me a Coffee link at `buymeacoffee.com/samlo122`.
+- Real coverage: featured in selfh.st "Self-Host Weekly" (26 June 2026), which drove the star spike; syndicated onward to Yahoo Tech.
+- **Absent — must not be fabricated:** no testimonials, no named users or customers, no install counts, no uptime/performance benchmarks beyond the measured compression figures (JS 271,913 → 61,001 bytes; CSS 66,634 → 12,265 bytes), no pricing or commercial tier.
+
+## Product Principles
+
+1. **One glance answers the question.** The default state is "everything is fine"; anything wrong must be findable without scrolling or clicking.
+2. **Never blank the board.** A dead integration, invalid config, or dropped stream degrades to an error inside its own card. The dashboard keeps rendering.
+3. **Push, don't poll.** Liveness is the product. The browser holds one EventSource and never sets a timer.
+4. **Zero-config to first value.** One container, one volume, no file to edit. Everything else is configured in the UI.
+5. **Credentials never reach the browser.** Server-side only, sanitized payloads, no exceptions — this is what makes a no-auth app defensible behind a VPN.
+
+## Accessibility & Inclusion
+
+**WCAG 2.2 AA is a real target**, confirmed by the user. As a public open-source project, AA is the credible bar, not an aspiration.
+
+Product-specific implications:
+
+- **Live status must be perceivable non-visually.** The core value is streamed state change; screen-reader users currently get silence. Live regions are a product requirement, not polish.
+- **Status must not be color-only.** Up/warn/down is currently a 9px colored dot. Needs a text or shape alternative (WCAG 1.4.1).
+- **Contrast must hold across all 22 themes.** Status tokens are currently declared once in `:root` and never re-tuned, so they measure 1.7–3.0:1 on the 11 light themes.
+- **Touch targets matter** because the phone scene is confirmed real (WCAG 2.5.8).
+
+Tracked as board task #177.

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -742,3 +742,43 @@ e2eLocalOnly('every control on a phone meets the 24px minimum tap target', async
   expect(undersized).toEqual([]);
   await page.close();
 }, 30_000);
+
+e2e('reduced motion removes movement but keeps feedback', async () => {
+  const calm = await browser.newPage({ reducedMotion: 'reduce' });
+  await calm.goto(BASE, { waitUntil: 'load' });
+  await calm.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const reduced = await calm.evaluate(() => {
+    const read = (sel: string) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const style = getComputedStyle(el);
+      return {
+        animation: style.animationName,
+        transitionProperty: style.transitionProperty,
+        transitionDuration: style.transitionDuration,
+      };
+    };
+    return { header: read('header.top'), page: read('.page'), button: read('.iconbtn') };
+  });
+
+  // Movement stops: the header no longer slides in from above.
+  expect(reduced.header?.animation).toBe('none');
+  // Feedback survives: a button still acknowledges hover and focus.
+  expect(reduced.button?.transitionProperty).toContain('background-color');
+  expect(reduced.button?.transitionDuration).not.toBe('0s');
+  // The regression this guards: `transition: none` on everything, which is
+  // what the rule used to do.
+  expect(reduced.button?.transitionProperty).not.toContain('transform');
+  await calm.close();
+
+  // And with no preference expressed, the full motion language is intact.
+  const lively = await browser.newPage({ reducedMotion: 'no-preference' });
+  await lively.goto(BASE, { waitUntil: 'load' });
+  await lively.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+  const full = await lively.evaluate(
+    () => getComputedStyle(document.querySelector('header.top') as Element).animationName,
+  );
+  expect(full).toBe('slide-down');
+  await lively.close();
+}, 30_000);

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -679,3 +679,66 @@ e2eLocalOnly('an unreachable service announces its failure through an alert regi
     await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
   }
 }, 30_000);
+
+// --- Responsive guards ----------------------------------------------------
+// Horizontal overflow is the kind of bug nobody reports and everybody feels:
+// the page rubber-bands sideways on a phone and the cause is one unshrinkable
+// flex child three levels down. Cheaper to assert than to rediscover.
+
+e2e('the board steps down through every column tier without overflowing', async () => {
+  const page = await browser.newPage();
+  const tiers = [
+    { width: 390, columns: '1' },
+    { width: 900, columns: '2' },
+    { width: 1200, columns: '3' },
+    { width: 1700, columns: '4' },
+  ];
+
+  for (const tier of tiers) {
+    await page.setViewportSize({ width: tier.width, height: 900 });
+    await page.goto(BASE, { waitUntil: 'load' });
+    await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+    await page.waitForTimeout(300);
+
+    const measured = await page.evaluate(() => ({
+      columns: getComputedStyle(document.querySelector('.grid') as Element).columnCount,
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+
+    expect(measured.columns, `column count at ${tier.width}px`).toBe(tier.columns);
+    expect(
+      measured.scrollWidth,
+      `${tier.width}px viewport scrolls horizontally (content is ${measured.scrollWidth}px)`,
+    ).toBeLessThanOrEqual(measured.clientWidth);
+  }
+
+  await page.close();
+}, 60_000);
+
+e2eLocalOnly('every control on a phone meets the 24px minimum tap target', async () => {
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const undersized = await page.evaluate(() => {
+    const small: string[] = [];
+    for (const el of document.querySelectorAll('a[href],button:not([disabled]),input')) {
+      const box = el.getBoundingClientRect();
+      if (box.width === 0 || box.height === 0) continue;
+      if (box.width < 24 || box.height < 24) {
+        const name = (el.className || el.tagName)
+          .toString()
+          .split(' ')
+          .filter((c) => !c.startsWith('svelte-'))
+          .join('.');
+        small.push(`${name} ${Math.round(box.width)}x${Math.round(box.height)}`);
+      }
+    }
+    return [...new Set(small)];
+  });
+
+  expect(undersized).toEqual([]);
+  await page.close();
+}, 30_000);

--- a/e2e/dashboard.test.ts
+++ b/e2e/dashboard.test.ts
@@ -545,3 +545,137 @@ e2e('Decorative motion is off by default and toggling it updates data-motion and
   });
   await page.close();
 }, 30_000);
+
+// --- Accessibility guards -------------------------------------------------
+// These lock in the semantics a screen reader depends on. They are cheap to
+// break silently (an attribute drops off in a refactor and nothing looks
+// wrong), which is exactly why they are asserted here.
+
+e2e('the dashboard exposes exactly one h1 and a live region for stream state', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  expect(await page.locator('h1').count()).toBe(1);
+  expect((await page.locator('h1').innerText()).trim().length).toBeGreaterThan(0);
+
+  // The reconnecting logo pulse is a visual-only signal; this is its text twin.
+  const streamStatus = page.locator('p.sr-only[role="status"]');
+  await streamStatus.waitFor({ state: 'attached', timeout: 5_000 });
+  expect(await streamStatus.innerText()).toContain('Live updates');
+
+  // sr-only must stay out of the layout while remaining in the a11y tree.
+  const box = await streamStatus.boundingBox();
+  expect(box?.width).toBeLessThanOrEqual(2);
+
+  await page.close();
+}, 30_000);
+
+e2e('every focusable control paints a focus ring', async () => {
+  const page = await browser.newPage();
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.locator('.card').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+  const selector = 'a[href],button:not([disabled]),input,textarea,select,[tabindex]:not([tabindex="-1"])';
+  const controls = await page.locator(selector).all();
+  expect(controls.length).toBeGreaterThan(5);
+
+  const unringed: string[] = [];
+  for (const control of controls) {
+    if (!(await control.isVisible().catch(() => false))) continue;
+    await control.focus().catch(() => {});
+    // Several controls use `transition: all`, so the ring animates in — read
+    // the settled value, not the frame the focus event landed on.
+    await page.waitForTimeout(250);
+    const info = await control.evaluate((node) => {
+      const style = getComputedStyle(node);
+      return {
+        ringless: style.outlineStyle === 'none' || style.outlineWidth === '0px',
+        label: node.getAttribute('aria-label') || node.textContent?.trim().slice(0, 30) || node.tagName,
+      };
+    });
+    if (info.ringless) unringed.push(info.label);
+  }
+  expect(unringed).toEqual([]);
+}, 60_000);
+
+e2eLocalOnly('a download bar with no printed percentage exposes progressbar semantics', async () => {
+  const createRes = await fetch(`${BASE}/api/integrations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Progress A11y E2E',
+      type: 'qbittorrent',
+      enabled: true,
+      refreshSeconds: 300,
+      config: { max: 5 },
+    }),
+  });
+  const { id } = (await createRes.json()) as { id: number };
+
+  const page = await browser.newPage();
+  try {
+    await page.route(`**/api/integrations/${id}/data`, async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          torrents: [
+            { name: 'ubuntu.iso', progress: 42, dlSpeed: 1024, upSpeed: 0, state: 'downloading', hash: 'h1' },
+          ],
+          aggregateDlSpeed: 1024,
+          aggregateUpSpeed: 0,
+        }),
+      });
+    });
+
+    await page.goto(BASE, { waitUntil: 'load' });
+    const card = page.getByRole('button', { name: /Progress A11y E2E/ });
+    await card.waitFor({ state: 'visible', timeout: 10_000 });
+    await card.click();
+
+    const dialog = page.locator('dialog[open]');
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+    const bar = dialog.getByRole('progressbar', { name: /ubuntu\.iso/ });
+    await bar.waitFor({ state: 'visible', timeout: 5_000 });
+    expect(await bar.getAttribute('aria-valuenow')).toBe('42');
+    expect(await bar.getAttribute('aria-valuemin')).toBe('0');
+    expect(await bar.getAttribute('aria-valuemax')).toBe('100');
+  } finally {
+    await page.close();
+    await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
+  }
+}, 30_000);
+
+e2eLocalOnly('an unreachable service announces its failure through an alert region', async () => {
+  const createRes = await fetch(`${BASE}/api/integrations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Alert A11y E2E',
+      type: 'adguard',
+      enabled: true,
+      refreshSeconds: 300,
+      config: { url: 'http://127.0.0.1:9', username: 'x', password: 'y' },
+    }),
+  });
+  const { id } = (await createRes.json()) as { id: number };
+
+  const page = await browser.newPage();
+  try {
+    await page.route(`**/api/integrations/${id}/data`, async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Unable to connect. Is the computer able to access the url?' }),
+      });
+    });
+    await page.goto(BASE, { waitUntil: 'load' });
+
+    const alert = page.getByRole('alert').filter({ hasText: 'Unable to connect' }).first();
+    await alert.waitFor({ state: 'visible', timeout: 10_000 });
+    expect(await alert.innerText()).toContain('Unable to connect');
+  } finally {
+    await page.close();
+    await fetch(`${BASE}/api/integrations/${id}`, { method: 'DELETE' });
+  }
+}, 30_000);

--- a/src/web/src/Root.svelte
+++ b/src/web/src/Root.svelte
@@ -26,7 +26,7 @@
 </script>
 
 {#if error}
-  <main class="page"><p class="state-msg error">{error}</p></main>
+  <main class="page"><p class="state-msg error" role="alert">{error}</p></main>
 {:else if route === '#settings'}
   <Settings />
 {:else if config}

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -188,7 +188,7 @@
   </div>
 
   {#if error}
-    <p class="state-msg error">{error}</p>
+    <p class="state-msg error" role="alert">{error}</p>
   {/if}
 
   {#if loading}

--- a/src/web/src/Settings.svelte
+++ b/src/web/src/Settings.svelte
@@ -294,7 +294,7 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--accent);
+    color: var(--accent-ink);
     margin-bottom: 6px;
   }
   .settings-sub {
@@ -343,7 +343,7 @@
   }
   .svc-mark.on {
     background: var(--accent-soft);
-    color: var(--accent);
+    color: var(--accent-ink);
     font-weight: 800;
   }
   .svc-title {
@@ -409,7 +409,7 @@
   }
   .type-pick:hover {
     border-color: var(--accent);
-    color: var(--accent);
+    color: var(--accent-ink);
   }
 
   @media (max-width: 640px) {

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -1747,12 +1747,54 @@ a.name {
   }
 }
 
+/* Reduced motion means less movement, not less feedback. The previous rule was
+   `animation: none; transition: none` on every element, which also removed the
+   colour and opacity changes that tell you a button took your click or a
+   dropdown opened — so the people who asked for a calmer interface got a less
+   legible one instead.
+   What follows removes movement and keeps acknowledgment. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
+    /* Only non-spatial properties may still transition. Anything that moves,
+       grows, or blurs snaps to its end state. */
+    transition-property:
+      opacity, color, background-color, border-color, box-shadow, fill, stroke !important;
+    transition-duration: 120ms !important;
+    animation-delay: 0ms !important;
+  }
+
+  /* Entrances: the page still fades, the header stops sliding in from above. */
+  header.top,
+  .tile,
+  .bar > *,
+  .beszel-disk-bar > *,
+  .usage > * {
     animation: none !important;
-    transition: none !important;
+  }
+
+  /* Decorative loops are already opt-in; reduced motion overrides the opt-in. */
+  :root[data-motion="on"] .brand .logo,
+  :root[data-motion="on"] .state-msg {
+    animation: none !important;
+  }
+
+  /* Kept, because each one is the only continuous signal for a live state:
+     the reconnecting logo, the live-activity dot, and the loading skeleton.
+     The logo pulse drops its scale and keeps the fade. */
+  .brand .logo.reconnecting {
+    animation-name: pulse-amber-flat !important;
+  }
+}
+
+@keyframes pulse-amber-flat {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
   }
 }
 
@@ -2120,9 +2162,10 @@ a.name {
   text-overflow: ellipsis;
 }
 
-/* ── animations: blanket motion layer ──────────────────────────────
-   All of this is killed by the prefers-reduced-motion guard above
-   (animation/transition: none !important wins regardless of order). */
+/* ── animations ────────────────────────────────────────────────────
+   Under prefers-reduced-motion the guard above keeps the entrance fade and
+   the three live-state loops, and stops everything that moves. It is not a
+   blanket kill — check that block before adding motion here. */
 
 /* page + header entrance */
 .page {

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -19,6 +19,29 @@
   --warn: #f2a33c;
   --down: #ff453a;
   --idle: #b6bac2;
+  /* Focus ring rides on --ink, which every theme redefines against its own
+     background — so the ring clears 3:1 on all 22 themes without per-theme work. */
+  --focus-ring: var(--ink);
+}
+
+/* One ring for the whole app. Components that need a different shape override
+   the radius, never the visibility. */
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Screen-reader-only text: present in the a11y tree, absent from layout. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 :root[data-theme="light"] {
@@ -566,6 +589,8 @@ header.top {
   display: flex;
   align-items: center;
   gap: 10px;
+  /* It's the page's h1 — reset the UA margin, keep the wordmark size. */
+  margin: 0;
   font-weight: 800;
   font-size: 1.2rem;
   letter-spacing: -0.02em;
@@ -647,11 +672,6 @@ header.top {
 .iconbtn:hover {
   color: var(--ink);
   box-shadow: var(--shadow-hi);
-}
-
-.iconbtn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 .theme-picker {
@@ -1110,11 +1130,6 @@ header.top {
 
 .btn:active {
   transform: scale(0.93);
-}
-
-.btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 .btn.pending {
@@ -1589,11 +1604,6 @@ header.top {
 
 .sw.on i {
   left: 24px;
-}
-
-.sw:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 .sess {
@@ -2352,7 +2362,6 @@ body::before {
   border-radius: var(--radius-sm);
   padding: 12px;
   color: var(--ink);
-  outline: none;
   resize: vertical;
   min-height: 120px;
 }

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -58,7 +58,7 @@
     linear-gradient(160deg, #fbf5ee, #f6efe8);
   /* This theme inherits --accent from :root, so it has no --accent-soft to sit
      beside; every other palette declares --accent-ink right after that pair. */
-  --accent-ink: #a86200;
+  --accent-ink: #a35f00;
   --glass: rgba(255, 255, 255, 0.55);
   --glass-2: rgba(255, 255, 255, 0.42);
   --glass-brd: rgba(255, 255, 255, 0.7);
@@ -67,7 +67,7 @@
   --surface-2: rgba(120, 120, 140, 0.16);
   --ink: #1d1d1f;
   --ink-dim: #62636a;
-  --ink-faint: #70727e;
+  --ink-faint: #6d6f7b;
   --shadow: 0 10px 34px rgba(40, 40, 60, 0.12);
   --shadow-hi: 0 14px 40px rgba(40, 40, 60, 0.18);
 }
@@ -89,7 +89,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f5f5f7;
   --ink-dim: #a9abb3;
-  --ink-faint: #7d8089;
+  --ink-faint: #81848d;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.62);
 }
@@ -123,7 +123,7 @@
     linear-gradient(160deg, #f7fee7, #d9f99d);
   --accent: #059669;
   --accent-soft: rgba(5, 150, 105, 0.14);
-  --accent-ink: #04865d;
+  --accent-ink: #048159;
   --glass: rgba(255, 255, 255, 0.56);
   --glass-2: rgba(255, 255, 255, 0.44);
   --glass-brd: rgba(16, 185, 129, 0.26);
@@ -132,7 +132,7 @@
   --surface-2: rgba(6, 78, 59, 0.13);
   --ink: #052e2b;
   --ink-dim: #3f625c;
-  --ink-faint: #607a75;
+  --ink-faint: #5d7671;
   --shadow: 0 10px 34px rgba(6, 78, 59, 0.12);
   --shadow-hi: 0 14px 40px rgba(6, 78, 59, 0.18);
 }
@@ -145,6 +145,7 @@
     linear-gradient(160deg, #fff1f2, #ffe4e6);
   --accent: #e11d48;
   --accent-soft: rgba(225, 29, 72, 0.14);
+  --accent-ink: #d81c45;
   --glass: rgba(255, 255, 255, 0.56);
   --glass-2: rgba(255, 255, 255, 0.44);
   --glass-brd: rgba(244, 63, 94, 0.24);
@@ -153,7 +154,7 @@
   --surface-2: rgba(136, 19, 55, 0.12);
   --ink: #3b0a1e;
   --ink-dim: #70425a;
-  --ink-faint: #97637c;
+  --ink-faint: #926078;
   --shadow: 0 10px 34px rgba(136, 19, 55, 0.12);
   --shadow-hi: 0 14px 40px rgba(136, 19, 55, 0.18);
 }
@@ -174,7 +175,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f9fafb;
   --ink-dim: #cbd5e1;
-  --ink-faint: #6c7d96;
+  --ink-faint: #74849c;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.52);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.64);
 }
@@ -229,7 +230,7 @@
     linear-gradient(160deg, #f0f4f8, #e5e9f0);
   --accent: #5e81ac;
   --accent-soft: rgba(94, 129, 172, 0.14);
-  --accent-ink: #5275a0;
+  --accent-ink: #50719b;
   --glass: rgba(255, 255, 255, 0.6);
   --glass-2: rgba(255, 255, 255, 0.45);
   --glass-brd: rgba(216, 222, 233, 0.8);
@@ -238,7 +239,7 @@
   --surface-2: rgba(76, 86, 106, 0.14);
   --ink: #2e3440;
   --ink-dim: #4c566a;
-  --ink-faint: #66748f;
+  --ink-faint: #626f89;
   --shadow: 0 10px 34px rgba(46, 52, 64, 0.1);
   --shadow-hi: 0 14px 40px rgba(46, 52, 64, 0.16);
 }
@@ -251,7 +252,7 @@
     linear-gradient(160deg, #fffaf3, #fdf4e7);
   --accent: #ea580c;
   --accent-soft: rgba(234, 88, 12, 0.14);
-  --accent-ink: #c94c0a;
+  --accent-ink: #c34a0a;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.44);
   --glass-brd: rgba(253, 186, 116, 0.55);
@@ -260,7 +261,7 @@
   --surface-2: rgba(124, 45, 18, 0.12);
   --ink: #431407;
   --ink-dim: #7c2d12;
-  --ink-faint: #b25e43;
+  --ink-faint: #ab5a40;
   --shadow: 0 10px 34px rgba(124, 45, 18, 0.1);
   --shadow-hi: 0 14px 40px rgba(124, 45, 18, 0.15);
 }
@@ -281,7 +282,7 @@
   --surface-2: rgba(255, 255, 255, 0.13);
   --ink: #f8f8f2;
   --ink-dim: #a2a6c2;
-  --ink-faint: #868bae;
+  --ink-faint: #8b90b1;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.68);
 }
@@ -302,7 +303,7 @@
   --surface-2: rgba(255, 255, 255, 0.11);
   --ink: #eceff4;
   --ink-dim: #d8dee9;
-  --ink-faint: #8e98ab;
+  --ink-faint: #939cae;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.65);
 }
@@ -344,7 +345,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f1f5f9;
   --ink-dim: #cbd5e1;
-  --ink-faint: #6c7d96;
+  --ink-faint: #74849c;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.52);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.64);
 }
@@ -420,7 +421,7 @@
     linear-gradient(160deg, #f9fafb, #e5e7eb);
   --accent: #65a30d;
   --accent-soft: rgba(101, 163, 13, 0.14);
-  --accent-ink: #51820a;
+  --accent-ink: #4e7d0a;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(156, 163, 175, 0.34);
@@ -429,7 +430,7 @@
   --surface-2: rgba(17, 24, 39, 0.11);
   --ink: #111827;
   --ink-dim: #4b5563;
-  --ink-faint: #6c7586;
+  --ink-faint: #687181;
   --shadow: 0 10px 34px rgba(17, 24, 39, 0.12);
   --shadow-hi: 0 14px 40px rgba(17, 24, 39, 0.18);
 }
@@ -442,7 +443,7 @@
     linear-gradient(160deg, #f0fdff, #cffafe);
   --accent: #0891b2;
   --accent-soft: rgba(8, 145, 178, 0.14);
-  --accent-ink: #07809d;
+  --accent-ink: #077b97;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(103, 232, 249, 0.4);
@@ -451,7 +452,7 @@
   --surface-2: rgba(8, 47, 73, 0.12);
   --ink: #083344;
   --ink-dim: #155e75;
-  --ink-faint: #4b7c8c;
+  --ink-faint: #487887;
   --shadow: 0 10px 34px rgba(8, 47, 73, 0.12);
   --shadow-hi: 0 14px 40px rgba(8, 47, 73, 0.18);
 }
@@ -464,7 +465,7 @@
     linear-gradient(160deg, #f0fdf4, #dcfce7);
   --accent: #16a34a;
   --accent-soft: rgba(22, 163, 74, 0.14);
-  --accent-ink: #12873d;
+  --accent-ink: #11823b;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(134, 239, 172, 0.4);
@@ -473,7 +474,7 @@
   --surface-2: rgba(20, 83, 45, 0.12);
   --ink: #14532d;
   --ink-dim: #3f6212;
-  --ink-faint: #5a7c63;
+  --ink-faint: #577860;
   --shadow: 0 10px 34px rgba(20, 83, 45, 0.12);
   --shadow-hi: 0 14px 40px rgba(20, 83, 45, 0.18);
 }
@@ -494,7 +495,7 @@
   --surface-2: rgba(40, 42, 54, 0.12);
   --ink: #282a36;
   --ink-dim: #5b5f7a;
-  --ink-faint: #6b7299;
+  --ink-faint: #676f96;
   --shadow: 0 10px 34px rgba(40, 42, 54, 0.12);
   --shadow-hi: 0 14px 40px rgba(40, 42, 54, 0.18);
 }

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -812,7 +812,17 @@ header.top {
   margin-bottom: 20px;
 }
 
+/* The board went straight from three columns to one at 1080px, so every width
+   between a phone and a laptop — iPad portrait, a half-screen window — got a
+   single stretched column. Two columns hold down to ~720px, where a card gets
+   too narrow to read a service name and a latency on one line. */
 @media (max-width: 1080px) {
+  .grid {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 720px) {
   .grid {
     column-count: 1;
   }
@@ -963,6 +973,9 @@ header.top {
   padding: 11px 0;
   font-size: 0.92rem;
   border-bottom: 1px solid var(--glass-brd);
+  /* Grid and flex children default to min-width:auto, which lets a long service
+     name push the row past its track instead of ellipsing. */
+  min-width: 0;
 }
 
 .row:first-child {
@@ -975,10 +988,23 @@ header.top {
 
 .row .name {
   flex: 1;
+  min-width: 0;
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* The service name is a link but only as tall as its text — 19px, under the 24
+   WCAG 2.5.8 asks for. Padding grows the hit box to 41px; the matching negative
+   margin takes that growth back out of the layout, so the row looks identical.
+   (A ::after overlay is the usual trick and does not work here: .name sets
+   overflow:hidden for its ellipsis, which clips the pseudo-element.)
+   11px matches the row's own padding, so neighbouring links meet without
+   overlapping. */
+a.name {
+  padding-block: 11px;
+  margin-block: -11px;
 }
 
 .row .ms {
@@ -994,7 +1020,8 @@ header.top {
 
 .tiles {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  /* Four across where there is room, fewer where there is not. */
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
   gap: 12px;
 }
 
@@ -1800,7 +1827,10 @@ header.top {
   display: block;
   width: 100%;
   margin-top: 14px;
-  padding: 0;
+  /* Was a 16px-tall tap target. WCAG 2.5.8 wants 24 minimum; the vertical
+     padding buys it without moving the text. */
+  padding: 4px 0;
+  min-height: 24px;
   text-align: left;
   background: none;
   border: none;
@@ -2656,8 +2686,12 @@ body::before {
   font-size: 0.75rem;
 }
 
+/* Compact pairs rows up, but only where a pair actually fits. repeat(2, 1fr)
+   forced two columns into a 342px phone card and each row then burst its own
+   track, pushing the page 8px wider than the viewport. auto-fit collapses to
+   one column on its own, at any width, with no breakpoint to maintain. */
 :root[data-density="compact"] .rows {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   column-gap: 12px;
 }

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -15,9 +15,14 @@
   --blur: saturate(180%) blur(12px);
   --accent: #ff9500;
   --accent-soft: rgba(255, 149, 0, 0.15);
+  /* --accent is a fill colour first: dots, bars, borders, active pills. Where it
+     has to be read as text it needs 4.5:1, which several light palettes miss —
+     those themes override --accent-ink with a darker cast of the same hue. */
+  --accent-ink: var(--accent);
+  /* Status colours for the dark themes; the light half is retuned below. */
   --ok: #30b85f;
   --warn: #f2a33c;
-  --down: #ff453a;
+  --down: #ff6b60;
   --idle: #b6bac2;
   /* Focus ring rides on --ink, which every theme redefines against its own
      background — so the ring clears 3:1 on all 22 themes without per-theme work. */
@@ -45,6 +50,7 @@
 }
 
 :root[data-theme="light"] {
+  --accent-ink: #a86200;
   --wall:
     radial-gradient(40% 50% at 18% 18%, #ffe2c2 0%, transparent 60%),
     radial-gradient(40% 50% at 82% 12%, #ffd9c9 0%, transparent 60%),
@@ -59,7 +65,7 @@
   --surface-2: rgba(120, 120, 140, 0.16);
   --ink: #1d1d1f;
   --ink-dim: #62636a;
-  --ink-faint: #9b9da6;
+  --ink-faint: #70727e;
   --shadow: 0 10px 34px rgba(40, 40, 60, 0.12);
   --shadow-hi: 0 14px 40px rgba(40, 40, 60, 0.18);
 }
@@ -81,7 +87,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f5f5f7;
   --ink-dim: #a9abb3;
-  --ink-faint: #70727b;
+  --ink-faint: #7d8089;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.62);
 }
@@ -102,7 +108,7 @@
   --surface-2: rgba(15, 23, 42, 0.11);
   --ink: #0f172a;
   --ink-dim: #475569;
-  --ink-faint: #94a3b8;
+  --ink-faint: #5d7290;
   --shadow: 0 10px 34px rgba(15, 23, 42, 0.12);
   --shadow-hi: 0 14px 40px rgba(15, 23, 42, 0.18);
 }
@@ -115,6 +121,7 @@
     linear-gradient(160deg, #f7fee7, #d9f99d);
   --accent: #059669;
   --accent-soft: rgba(5, 150, 105, 0.14);
+  --accent-ink: #04865d;
   --glass: rgba(255, 255, 255, 0.56);
   --glass-2: rgba(255, 255, 255, 0.44);
   --glass-brd: rgba(16, 185, 129, 0.26);
@@ -123,7 +130,7 @@
   --surface-2: rgba(6, 78, 59, 0.13);
   --ink: #052e2b;
   --ink-dim: #3f625c;
-  --ink-faint: #78958f;
+  --ink-faint: #607a75;
   --shadow: 0 10px 34px rgba(6, 78, 59, 0.12);
   --shadow-hi: 0 14px 40px rgba(6, 78, 59, 0.18);
 }
@@ -144,7 +151,7 @@
   --surface-2: rgba(136, 19, 55, 0.12);
   --ink: #3b0a1e;
   --ink-dim: #70425a;
-  --ink-faint: #a7798f;
+  --ink-faint: #97637c;
   --shadow: 0 10px 34px rgba(136, 19, 55, 0.12);
   --shadow-hi: 0 14px 40px rgba(136, 19, 55, 0.18);
 }
@@ -165,7 +172,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f9fafb;
   --ink-dim: #cbd5e1;
-  --ink-faint: #64748b;
+  --ink-faint: #6c7d96;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.52);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.64);
 }
@@ -220,6 +227,7 @@
     linear-gradient(160deg, #f0f4f8, #e5e9f0);
   --accent: #5e81ac;
   --accent-soft: rgba(94, 129, 172, 0.14);
+  --accent-ink: #5275a0;
   --glass: rgba(255, 255, 255, 0.6);
   --glass-2: rgba(255, 255, 255, 0.45);
   --glass-brd: rgba(216, 222, 233, 0.8);
@@ -228,7 +236,7 @@
   --surface-2: rgba(76, 86, 106, 0.14);
   --ink: #2e3440;
   --ink-dim: #4c566a;
-  --ink-faint: #6c7a96;
+  --ink-faint: #66748f;
   --shadow: 0 10px 34px rgba(46, 52, 64, 0.1);
   --shadow-hi: 0 14px 40px rgba(46, 52, 64, 0.16);
 }
@@ -241,6 +249,7 @@
     linear-gradient(160deg, #fffaf3, #fdf4e7);
   --accent: #ea580c;
   --accent-soft: rgba(234, 88, 12, 0.14);
+  --accent-ink: #c94c0a;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.44);
   --glass-brd: rgba(253, 186, 116, 0.55);
@@ -270,7 +279,7 @@
   --surface-2: rgba(255, 255, 255, 0.13);
   --ink: #f8f8f2;
   --ink-dim: #a2a6c2;
-  --ink-faint: #7b81a7;
+  --ink-faint: #868bae;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.68);
 }
@@ -291,7 +300,7 @@
   --surface-2: rgba(255, 255, 255, 0.11);
   --ink: #eceff4;
   --ink-dim: #d8dee9;
-  --ink-faint: #818ca2;
+  --ink-faint: #8e98ab;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.65);
 }
@@ -333,7 +342,7 @@
   --surface-2: rgba(255, 255, 255, 0.1);
   --ink: #f1f5f9;
   --ink-dim: #cbd5e1;
-  --ink-faint: #64748b;
+  --ink-faint: #6c7d96;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.52);
   --shadow-hi: 0 16px 48px rgba(0, 0, 0, 0.64);
 }
@@ -409,6 +418,7 @@
     linear-gradient(160deg, #f9fafb, #e5e7eb);
   --accent: #65a30d;
   --accent-soft: rgba(101, 163, 13, 0.14);
+  --accent-ink: #51820a;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(156, 163, 175, 0.34);
@@ -417,7 +427,7 @@
   --surface-2: rgba(17, 24, 39, 0.11);
   --ink: #111827;
   --ink-dim: #4b5563;
-  --ink-faint: #9ca3af;
+  --ink-faint: #6c7586;
   --shadow: 0 10px 34px rgba(17, 24, 39, 0.12);
   --shadow-hi: 0 14px 40px rgba(17, 24, 39, 0.18);
 }
@@ -430,6 +440,7 @@
     linear-gradient(160deg, #f0fdff, #cffafe);
   --accent: #0891b2;
   --accent-soft: rgba(8, 145, 178, 0.14);
+  --accent-ink: #07809d;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(103, 232, 249, 0.4);
@@ -438,7 +449,7 @@
   --surface-2: rgba(8, 47, 73, 0.12);
   --ink: #083344;
   --ink-dim: #155e75;
-  --ink-faint: #5a93a6;
+  --ink-faint: #4b7c8c;
   --shadow: 0 10px 34px rgba(8, 47, 73, 0.12);
   --shadow-hi: 0 14px 40px rgba(8, 47, 73, 0.18);
 }
@@ -451,6 +462,7 @@
     linear-gradient(160deg, #f0fdf4, #dcfce7);
   --accent: #16a34a;
   --accent-soft: rgba(22, 163, 74, 0.14);
+  --accent-ink: #12873d;
   --glass: rgba(255, 255, 255, 0.58);
   --glass-2: rgba(255, 255, 255, 0.46);
   --glass-brd: rgba(134, 239, 172, 0.4);
@@ -459,7 +471,7 @@
   --surface-2: rgba(20, 83, 45, 0.12);
   --ink: #14532d;
   --ink-dim: #3f6212;
-  --ink-faint: #6b9476;
+  --ink-faint: #5a7c63;
   --shadow: 0 10px 34px rgba(20, 83, 45, 0.12);
   --shadow-hi: 0 14px 40px rgba(20, 83, 45, 0.18);
 }
@@ -480,7 +492,7 @@
   --surface-2: rgba(40, 42, 54, 0.12);
   --ink: #282a36;
   --ink-dim: #5b5f7a;
-  --ink-faint: #9499b5;
+  --ink-faint: #6b7299;
   --shadow: 0 10px 34px rgba(40, 42, 54, 0.12);
   --shadow-hi: 0 14px 40px rgba(40, 42, 54, 0.18);
 }
@@ -504,6 +516,18 @@
   --ink-faint: #a8527e;
   --shadow: 0 10px 34px rgba(124, 0, 64, 0.12);
   --shadow-hi: 0 14px 40px rgba(124, 0, 64, 0.18);
+}
+
+/* Every light palette lands its cards between L=0.96 and L=0.99, so one retuned
+   status set serves all eleven. The dark values above stay: they already clear
+   AA on their own backgrounds and dimming them would flatten the board.
+   These are read as text (`color: var(--down)`) as well as painted into 9px
+   dots, so they are held to 4.5:1, not the 3:1 a pure indicator would need. */
+:root[data-theme^="light"] {
+  --ok: #15803d;
+  --warn: #b45309;
+  --down: #b91c1c;
+  --idle: #64748b;
 }
 
 * {
@@ -767,7 +791,7 @@ header.top {
 }
 .card a:hover,
 .modal-panel a:hover {
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 
 .grid {
@@ -880,7 +904,7 @@ header.top {
   height: 31px;
   border-radius: 10px;
   background: var(--accent-soft);
-  color: var(--accent);
+  color: var(--accent-ink);
   display: grid;
   place-items: center;
   flex: none;
@@ -1199,7 +1223,7 @@ header.top {
 .pct {
   font-size: 0.82rem;
   font-weight: 700;
-  color: var(--accent);
+  color: var(--accent-ink);
   font-variant-numeric: tabular-nums;
 }
 
@@ -1236,7 +1260,7 @@ header.top {
 }
 
 .spd .dn {
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 
 .mini-list {
@@ -1316,7 +1340,7 @@ header.top {
 }
 
 .gauge .v.accent {
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 
 .gauge .k {
@@ -1356,7 +1380,7 @@ header.top {
 .beszel-summary b {
   display: block;
   margin-top: 3px;
-  color: var(--accent);
+  color: var(--accent-ink);
   font-size: 1.3rem;
   line-height: 1;
   font-variant-numeric: tabular-nums;
@@ -1659,7 +1683,7 @@ header.top {
 
 .jf .who {
   font-size: 0.72rem;
-  color: var(--accent);
+  color: var(--accent-ink);
   font-weight: 700;
 }
 
@@ -1784,7 +1808,7 @@ header.top {
   font-family: inherit;
   font-size: 0.78rem;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 
 /* generic modal (Modal.svelte) */
@@ -1861,7 +1885,7 @@ header.top {
   text-align: center;
   font-weight: 700;
   font-size: 0.78rem;
-  color: var(--accent);
+  color: var(--accent-ink);
   font-variant-numeric: tabular-nums;
   padding-top: 1px;
 }
@@ -2019,7 +2043,7 @@ header.top {
   flex: 0 0 64px;
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accent-ink);
   font-variant-numeric: tabular-nums;
 }
 

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -2297,7 +2297,13 @@ header.top {
   }
 }
 
-/* meter / progress bars grow on load */
+/* meter / progress bars grow on load.
+   These animate `width`, which linters flag as layout thrash and the textbook
+   answer is transform: scaleX. Benchmarked both at 6x CPU throttle with 40
+   simultaneous bars, twice: width held a 16.7-16.9ms median with 1-3 late
+   frames, scaleX came in at 17.4-17.6ms with 5-14. Promoting forty 3px bars to
+   their own compositor layers costs more than laying them out inside an already
+   contained card. Left as width on purpose — measure again before changing it. */
 .bar > *,
 .beszel-disk-bar > *,
 .usage > * {

--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -50,13 +50,15 @@
 }
 
 :root[data-theme="light"] {
-  --accent-ink: #a86200;
   --wall:
     radial-gradient(40% 50% at 18% 18%, #ffe2c2 0%, transparent 60%),
     radial-gradient(40% 50% at 82% 12%, #ffd9c9 0%, transparent 60%),
     radial-gradient(45% 55% at 75% 82%, #fff0c4 0%, transparent 58%),
     radial-gradient(40% 50% at 12% 88%, #ffe6cf 0%, transparent 55%),
     linear-gradient(160deg, #fbf5ee, #f6efe8);
+  /* This theme inherits --accent from :root, so it has no --accent-soft to sit
+     beside; every other palette declares --accent-ink right after that pair. */
+  --accent-ink: #a86200;
   --glass: rgba(255, 255, 255, 0.55);
   --glass-2: rgba(255, 255, 255, 0.42);
   --glass-brd: rgba(255, 255, 255, 0.7);

--- a/src/web/src/components/BackupPanel.svelte
+++ b/src/web/src/components/BackupPanel.svelte
@@ -140,7 +140,7 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--accent);
+    color: var(--accent-ink);
     margin-bottom: 6px;
   }
   .settings-sub {

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -251,20 +251,26 @@
 
 <header class="top">
   <div class="top-in">
-    <div class="brand">
-      <img class="logo" class:reconnecting={!connectedVal} src="/icons/labby.svg" alt="Labby" width="28" height="28" />
+    <h1 class="brand">
+      <img class="logo" class:reconnecting={!connectedVal} src="/icons/labby.svg" alt="" width="28" height="28" />
       <span>{title.toLowerCase()}</span>
-    </div>
+    </h1>
+
+    <!-- The reconnecting logo pulse is the only signal a sighted user gets; this
+         is the same signal for everyone else. -->
+    <p class="sr-only" role="status">
+      {connectedVal ? 'Live updates connected' : 'Live updates disconnected, reconnecting'}
+    </p>
 
     {#if currentTime}
       <span class="header-time">{currentTime}</span>
     {/if}
 
     {#if monitorIds.length > 0}
-      <div class="summary">
-        <span class="chip" title="Monitored sites up"><span class="dot ok"></span><b>{summary.up}</b></span>
-        <span class="chip" title="Monitored sites warning"><span class="dot warn"></span><b>{summary.warn}</b></span>
-        <span class="chip" title="Monitored sites down"><span class="dot down"></span><b>{summary.down}</b></span>
+      <div class="summary" role="status" aria-label="Monitored sites">
+        <span class="chip" title="Monitored sites up"><span class="dot ok"></span><b>{summary.up}</b><span class="sr-only"> up</span></span>
+        <span class="chip" title="Monitored sites warning"><span class="dot warn"></span><b>{summary.warn}</b><span class="sr-only"> warning</span></span>
+        <span class="chip" title="Monitored sites down"><span class="dot down"></span><b>{summary.down}</b><span class="sr-only"> down</span></span>
       </div>
     {/if}
 

--- a/src/web/src/components/Header.svelte
+++ b/src/web/src/components/Header.svelte
@@ -409,6 +409,6 @@
 
   .mode-btn.active {
     background: var(--accent-soft);
-    color: var(--accent);
+    color: var(--accent-ink);
   }
 </style>

--- a/src/web/src/components/IconPicker.svelte
+++ b/src/web/src/components/IconPicker.svelte
@@ -403,7 +403,7 @@
   }
   .ip-tab.active {
     background: var(--accent-soft);
-    color: var(--accent);
+    color: var(--accent-ink);
   }
 
   .ip-searchbar {
@@ -560,7 +560,7 @@
     font-family: var(--mono, ui-monospace, monospace);
     font-size: 0.76rem;
     font-weight: 600;
-    color: var(--accent);
+    color: var(--accent-ink);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/web/src/components/IconPicker.svelte
+++ b/src/web/src/components/IconPicker.svelte
@@ -428,7 +428,6 @@
     border-radius: var(--radius-sm);
     padding: 8px 10px;
     color: var(--ink);
-    outline: none;
   }
   .ip-searchbar .ip-input {
     padding-left: 32px;

--- a/src/web/src/components/IntegrationForm.svelte
+++ b/src/web/src/components/IntegrationForm.svelte
@@ -493,7 +493,6 @@
     border-radius: var(--radius-sm);
     padding: 10px 12px;
     color: var(--ink);
-    outline: none;
   }
   /* The rule above targets every input; checkboxes must opt out of full-width box styling. */
   input[type="checkbox"] {

--- a/src/web/src/components/Select.svelte
+++ b/src/web/src/components/Select.svelte
@@ -287,7 +287,7 @@
 
   .select-option.selected {
     background: var(--accent-soft);
-    color: var(--accent);
+    color: var(--accent-ink);
     font-weight: 700;
   }
 

--- a/src/web/src/components/Select.svelte
+++ b/src/web/src/components/Select.svelte
@@ -340,6 +340,23 @@
   :global([data-theme="dark-cyberpunk"]) .custom-select:hover { background: #1c0a3a; }
   :global([data-theme="dark-cyberpunk"]) .select-dropdown { background: #120626; }
 
+  /* The dropdown still needs to announce that it opened; under reduced motion
+     it fades in place instead of rising. */
+  @media (prefers-reduced-motion: reduce) {
+    .select-dropdown {
+      animation-name: fadeIn;
+    }
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
   @keyframes slideUp {
     from {
       opacity: 0;

--- a/src/web/src/components/Select.svelte
+++ b/src/web/src/components/Select.svelte
@@ -179,7 +179,6 @@
     border-radius: var(--radius-sm);
     cursor: pointer;
     user-select: none;
-    outline: none;
     transition: all 0.2s var(--ease);
     box-sizing: border-box;
   }

--- a/src/web/src/lib/theme-contrast.test.ts
+++ b/src/web/src/lib/theme-contrast.test.ts
@@ -1,0 +1,154 @@
+// Contrast is the one design property that breaks silently: a palette gets
+// hand-tuned, a token drifts, and nothing looks wrong until someone on a light
+// theme cannot read a status line. This parses app.css and does the WCAG maths
+// on every theme, so a regression fails the suite instead of shipping.
+//
+// It approximates each card's real background — the glass layer composited over
+// the wall gradient — rather than testing against the raw gradient, because no
+// text in the app sits directly on the wall.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CSS = readFileSync(join(import.meta.dir, '..', 'app.css'), 'utf8');
+
+type RGB = [number, number, number];
+
+function parseHex(hex: string): RGB {
+  const h = hex.replace('#', '');
+  return [
+    Number.parseInt(h.slice(0, 2), 16),
+    Number.parseInt(h.slice(2, 4), 16),
+    Number.parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+function relativeLuminance([r, g, b]: RGB): number {
+  const channel = (v: number) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: RGB, b: RGB): number {
+  const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function composite(fg: RGB, alpha: number, bg: RGB): RGB {
+  return [0, 1, 2].map((i) => alpha * fg[i] + (1 - alpha) * bg[i]) as RGB;
+}
+
+/** The four status tokens live outside the theme blocks — one set per mode. */
+function readGlobalTokens(prefix: 'dark' | 'light') {
+  if (prefix === 'light') {
+    const block = CSS.match(/:root\[data-theme\^="light"\]\s*\{([^}]*)\}/)?.[1] ?? '';
+    return Object.fromEntries(
+      [...block.matchAll(/--(\w[\w-]*):\s*(#[0-9a-fA-F]{6})/g)].map((m) => [m[1], m[2]]),
+    );
+  }
+  const root = CSS.match(/^:root\s*\{([\s\S]*?)\n\}/m)?.[1] ?? '';
+  return Object.fromEntries(
+    [...root.matchAll(/--(\w[\w-]*):\s*(#[0-9a-fA-F]{6})/g)].map((m) => [m[1], m[2]]),
+  );
+}
+
+interface Theme {
+  name: string;
+  card: RGB;
+  tokens: Record<string, string>;
+}
+
+function parseThemes(): Theme[] {
+  const themes: Theme[] = [];
+  for (const match of CSS.matchAll(/:root\[data-theme="([^"]+)"\]\s*\{([\s\S]*?)\n\}/g)) {
+    const [, name, body] = match;
+    const gradient = body.match(
+      /linear-gradient\(160deg,\s*(#[0-9a-fA-F]{6}),\s*(#[0-9a-fA-F]{6})\)/,
+    );
+    const glass = body.match(/--glass:\s*rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)/);
+    if (!gradient || !glass) throw new Error(`theme ${name} is missing a wall gradient or glass`);
+
+    const stops: RGB[] = [parseHex(gradient[1]), parseHex(gradient[2])];
+    const isDark = name.startsWith('dark');
+    // Worst case for the text: the lightest stop under a light theme, the
+    // darkest under a dark one.
+    const wall = stops.reduce((a, b) =>
+      isDark
+        ? relativeLuminance(a) < relativeLuminance(b)
+          ? a
+          : b
+        : relativeLuminance(a) > relativeLuminance(b)
+          ? a
+          : b,
+    );
+    const glassRGB: RGB = [Number(glass[1]), Number(glass[2]), Number(glass[3])];
+
+    const tokens = Object.fromEntries(
+      [...body.matchAll(/--(\w[\w-]*):\s*(#[0-9a-fA-F]{6})/g)].map((m) => [m[1], m[2]]),
+    );
+    const globals = readGlobalTokens(isDark ? 'dark' : 'light');
+
+    const resolved = { ...globals, ...tokens };
+    // --accent-ink is declared as `var(--accent)` in the base :root and only
+    // overridden with a literal where the accent misses 4.5:1. Mirror that
+    // fallback here rather than parsing var() chains.
+    if (!resolved['accent-ink']) resolved['accent-ink'] = resolved.accent;
+
+    themes.push({
+      name,
+      card: composite(glassRGB, Number(glass[4]), wall),
+      tokens: resolved,
+    });
+  }
+  return themes;
+}
+
+const THEMES = parseThemes();
+
+// Tokens that are painted as text somewhere in the app, so all of them owe 4.5:1.
+// --accent is deliberately absent: it is a fill colour, and --accent-ink is the
+// variant used wherever it has to be read.
+const TEXT_TOKENS = ['ink', 'ink-dim', 'ink-faint', 'accent-ink', 'ok', 'warn', 'down'];
+
+describe('theme contrast', () => {
+  test('every theme is discovered', () => {
+    expect(THEMES.length).toBe(22);
+    expect(THEMES.filter((t) => t.name.startsWith('light')).length).toBe(11);
+    expect(THEMES.filter((t) => t.name.startsWith('dark')).length).toBe(11);
+  });
+
+  test('every text token clears WCAG AA (4.5:1) on its own card background', () => {
+    const failures: string[] = [];
+    for (const theme of THEMES) {
+      for (const token of TEXT_TOKENS) {
+        const value = theme.tokens[token];
+        expect(value, `${theme.name} is missing --${token}`).toBeDefined();
+        const ratio = contrast(parseHex(value), theme.card);
+        if (ratio < 4.5) failures.push(`${theme.name} --${token} ${value} = ${ratio.toFixed(2)}:1`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  test('--idle clears the 3:1 required of a non-text indicator', () => {
+    const failures: string[] = [];
+    for (const theme of THEMES) {
+      const ratio = contrast(parseHex(theme.tokens.idle), theme.card);
+      if (ratio < 3) failures.push(`${theme.name} --idle = ${ratio.toFixed(2)}:1`);
+    }
+    expect(failures).toEqual([]);
+  });
+
+  test('status tokens are defined once per mode, not left to the base :root alone', () => {
+    // The bug this guards: --ok/--warn/--down/--idle sat in :root and were never
+    // retuned, so all eleven light themes rendered them at 1.7-3.0:1.
+    const lightBlock = CSS.match(/:root\[data-theme\^="light"\]\s*\{([^}]*)\}/)?.[1];
+    expect(lightBlock).toBeDefined();
+    for (const token of ['--ok', '--warn', '--down', '--idle']) {
+      expect(lightBlock).toContain(token);
+    }
+  });
+});

--- a/src/web/src/widgets/AdGuard.svelte
+++ b/src/web/src/widgets/AdGuard.svelte
@@ -41,7 +41,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:120px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if state.data}
     <div class="gauges">
       <div class="gauge"><div class="v">{formatNumber(state.data.queries)}</div><div class="k">Queries · 24h</div></div>

--- a/src/web/src/widgets/Arr.svelte
+++ b/src/web/src/widgets/Arr.svelte
@@ -24,7 +24,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:112px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if state.data}
     <div class="gauges">
       <div class="gauge"><div class="v accent">{state.data.queue}</div><div class="k">Queued</div></div>

--- a/src/web/src/widgets/Beszel.svelte
+++ b/src/web/src/widgets/Beszel.svelte
@@ -86,7 +86,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:168px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if visible.length === 0}
     <p class="state-msg">No systems</p>
   {:else}
@@ -141,7 +141,7 @@
             </div>
           </div>
           {#if disk.usedPercent != null}
-            <div class="bar beszel-disk-bar {hotClass(disk.usedPercent)}">
+            <div class="bar beszel-disk-bar {hotClass(disk.usedPercent)}" aria-hidden="true">
               <i style:width="{clampPercent(disk.usedPercent)}%"></i>
             </div>
           {/if}

--- a/src/web/src/widgets/Bookmarks.svelte
+++ b/src/web/src/widgets/Bookmarks.svelte
@@ -28,7 +28,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:96px"></div>
   {:else if state.error}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if links.length === 0}
     <p class="state-msg">No bookmarks</p>
   {:else}

--- a/src/web/src/widgets/Calendar.svelte
+++ b/src/web/src/widgets/Calendar.svelte
@@ -89,7 +89,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:120px"></div>
   {:else if state.error}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if !events.length}
     <p class="state-msg">Nothing coming up</p>
   {:else}

--- a/src/web/src/widgets/Docker.svelte
+++ b/src/web/src/widgets/Docker.svelte
@@ -69,7 +69,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:72px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else}
     <div class="gauges">
       <div class="gauge"><div class="v">{running}</div><div class="k">Running</div></div>
@@ -96,7 +96,7 @@
         </div>
         <div class="usage">
           {#if c.state === 'running' && c.cpuPercent != null}
-            cpu <span class="meter" class:hot={c.cpuPercent > 50}><i style:width="{c.cpuPercent}%"></i></span>
+            cpu <span class="meter" class:hot={c.cpuPercent > 50} aria-hidden="true"><i style:width="{c.cpuPercent}%"></i></span>
             {c.cpuPercent}%
           {:else}
             <span style="color:var(--ink-faint)">—</span>

--- a/src/web/src/widgets/Downloads.svelte
+++ b/src/web/src/widgets/Downloads.svelte
@@ -78,7 +78,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:72px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else}
     <div class="gauges">
       <div class="gauge"><div class="v accent">{counts.downloading}</div><div class="k">Downloading</div></div>
@@ -112,7 +112,15 @@
               <Icon icon={paused ? 'lucide:play' : 'lucide:pause'} size={15} />
             </button>
           </div>
-          <div class="bar"><i style:width="{clampPercent(t.progress)}%"></i></div>
+          <!-- No percentage is printed next to this bar, so it has to carry the value itself. -->
+          <div
+            class="bar"
+            role="progressbar"
+            aria-label="{t.name} download progress"
+            aria-valuenow={Math.round(clampPercent(t.progress))}
+            aria-valuemin="0"
+            aria-valuemax="100"
+          ><i style:width="{clampPercent(t.progress)}%"></i></div>
           <div class="spd">
             <span class="dn">↓ {formatBytesPerSec(t.dlSpeed)}</span>
             <span>↑ {formatBytesPerSec(t.upSpeed)}</span>

--- a/src/web/src/widgets/Feed.svelte
+++ b/src/web/src/widgets/Feed.svelte
@@ -48,7 +48,7 @@
     {#if state.loading && !state.data}
       <div class="skeleton" style="height:120px"></div>
     {:else if state.error}
-      <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+      <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
     {:else if posts.length === 0}
       <p class="state-msg">No posts</p>
     {:else}

--- a/src/web/src/widgets/MediaSessions.svelte
+++ b/src/web/src/widgets/MediaSessions.svelte
@@ -45,7 +45,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:72px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if !state.data?.sessions?.length}
     <p class="state-msg empty">No active sessions</p>
   {:else}
@@ -63,7 +63,15 @@
             <div class="cti">{s.title}</div>
             <div class="sub">{s.subtitle}</div>
             <div class="who">{s.user} · {s.device}</div>
-            <div class="bar"><i style:width="{clampPercent(s.progress)}%"></i></div>
+            <!-- No percentage is printed next to this bar, so it has to carry the value itself. -->
+            <div
+              class="bar"
+              role="progressbar"
+              aria-label="{s.title} playback progress"
+              aria-valuenow={Math.round(clampPercent(s.progress))}
+              aria-valuemin="0"
+              aria-valuemax="100"
+            ><i style:width="{clampPercent(s.progress)}%"></i></div>
           </div>
         </div>
       {/each}

--- a/src/web/src/widgets/Monitor.svelte
+++ b/src/web/src/widgets/Monitor.svelte
@@ -42,7 +42,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:48px"></div>
   {:else if state.error && rows.length === 0}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if rows.length === 0}
     <p class="state-msg">No sites configured</p>
   {:else if variant === 'tiles'}

--- a/src/web/src/widgets/Rawkoon.svelte
+++ b/src/web/src/widgets/Rawkoon.svelte
@@ -20,7 +20,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:132px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if state.data}
     <div class="gauges">
       <div class="gauge"><div class="v accent">{upcoming.length}</div><div class="k">Upcoming</div></div>

--- a/src/web/src/widgets/Sabnzbd.svelte
+++ b/src/web/src/widgets/Sabnzbd.svelte
@@ -69,7 +69,7 @@
   {#if state.loading && !state.data}
     <div class="skeleton" style="height:72px"></div>
   {:else if state.error && !state.data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if !slots.length}
     <p class="state-msg empty">Queue empty</p>
   {:else}
@@ -91,7 +91,7 @@
               <Icon icon={paused ? 'lucide:play' : 'lucide:pause'} size={15} />
             </button>
           </div>
-          <div class="bar"><i style:width="{clampPercent(s.progress)}%"></i></div>
+          <div class="bar" aria-hidden="true"><i style:width="{clampPercent(s.progress)}%"></i></div>
           <div class="spd">
             <span style="color:var(--ink-faint)">
               {paused ? 'paused' : s.status.toLowerCase()} · {s.timeLeft || '—'}

--- a/src/web/src/widgets/Speedtest.svelte
+++ b/src/web/src/widgets/Speedtest.svelte
@@ -119,7 +119,7 @@
   {#if state.loading && !data}
     <div class="skeleton" style="height:160px"></div>
   {:else if state.error && !data}
-    <p class="state-msg error"><span class="dot down"></span>{state.error}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{state.error}</p>
   {:else if data}
     <div class="gauges">
       <div class="gauge">

--- a/src/web/src/widgets/Speedtest.svelte
+++ b/src/web/src/widgets/Speedtest.svelte
@@ -306,7 +306,7 @@
   }
 
   .history-dl {
-    color: var(--accent);
+    color: var(--accent-ink);
   }
 
   .history-ul {

--- a/src/web/src/widgets/Weather.svelte
+++ b/src/web/src/widgets/Weather.svelte
@@ -29,7 +29,7 @@
   {#if state.loading && !data}
     <div class="skeleton" style="height:140px"></div>
   {:else if locationError && !data}
-    <p class="state-msg error"><span class="dot down"></span>{locationError}</p>
+    <p class="state-msg error" role="alert"><span class="dot down" aria-hidden="true"></span>{locationError}</p>
   {:else if data}
     <div class="weather-hero">
       <img class="weather-icon" src={weatherIconUrl(data.icon)} alt="" width="72" height="72" />


### PR DESCRIPTION
Closes the accessibility, responsive and motion findings from the Impeccable audit, plus a performance pass that deliberately ships nothing. Eight commits, verified throughout against a clone of the production database — 16 real integrations, real error states, not fixtures.

**Audit score: 14/20 → 19/20.**

| Dimension | Before | After |
|---|---|---|
| Accessibility | 2 | 4 |
| Performance | 3 | 4 |
| Responsive | 2 | 4 |
| Theming | 3 | 4 |
| Implementation integrity | 4 | 3 |

Integrity drops a point on purpose: four `transition: width` rules now survive a linter warning on the strength of a benchmark, which is a deliberate exception a reader has to be told about rather than a clean sheet.

---

## Accessibility — WCAG 2.2 AA

**Focus.** `IntegrationForm`'s `outline: none` applied to every input in the form with no replacement, so keyboard users lost their place mid-task. One global `:focus-visible` ring now covers the app, coloured from `--ink` so a single rule clears 3:1 on all 22 themes. Three per-component rules that re-coloured the ring with `--accent` (1.93:1 on light) are gone. Zero `outline: none` remain.

**Live regions.** The architecture is SSE → store → widget, and none of it was announced. `role="status"` on stream connection and the monitor counts, `role="alert"` on all 15 widget error states.

**Progress.** `role="progressbar"` with `aria-valuenow` on the two bars that print no percentage; `aria-hidden` on the three that sit beside one and were announced twice.

**Colour independence.** The header up/warn/down counts were a 9px dot and nothing else. They now carry screen-reader text.

**Structure.** The dashboard had no `h1`. The header wordmark is now it, visually identical.

The resulting accessibility tree: `heading "labby" [level=1]`, `status: Live updates connected`, `status "Monitored sites": 2 up 0 warning 15 down`, labelled theme group, named buttons.

## Contrast — every theme, every text token

`--ok`, `--warn`, `--down` and `--idle` were declared once in `:root` and never re-tuned, so all 22 themes shared one set built for dark backgrounds. The eleven light palettes rendered them at **1.71–2.99:1** while being used as `color:` in 18 places.

| Token | Light before | After |
|---|---|---|
| `--ok` | 2.26:1 | 4.94:1 |
| `--warn` | 1.83:1 | 4.94:1 |
| `--down` | 2.99:1 | 6.37:1 |
| `--idle` | 1.71:1 | 4.68:1 |
| `--accent` as text | 1.93:1 | 4.80:1+ |

Every light card composites to L=0.96–0.99, so one `[data-theme^="light"]` block serves all eleven — four lines, not forty-four. `--accent` stays the brand fill; a new `--accent-ink` is the readable cast, overridden only where the brand hue cannot reach the bar. `--ink-faint` was re-derived along each palette's own hue rather than flattened to a shared grey.

**All 176 token/theme pairs clear AA, lowest text value 4.75:1.** Contrast is measured against the composited card — glass over wall gradient — because no text in this app sits on the raw gradient.

## Responsive

The board went from three columns straight to one at 1080px, so iPad portrait and any half-screen window got a single stretched column. The ladder is now 1 / 2 / 3 / 4 at 390 / 900 / 1200 / 1700.

Phones were **scrolling sideways**: compact density set `.rows` to `repeat(2, 1fr)` at every width, and because grid children default to `min-width: auto` each row burst its own track, making the document 398px wide in a 390px viewport. `auto-fit` with a 180px floor collapses on its own at any width.

Tap targets were **measured, not assumed**. Every button already cleared the 24px floor at 29–42px; the failures were the text links — service names at 219×**19** and `.card-cta` at 316×**16**. Nothing was inflated to 44px for its own sake, because desktop density is a stated product requirement.

## Motion

`prefers-reduced-motion` was `animation: none; transition: none !important` on every element — which also removed the colour change that tells you a button took your click. Reduced motion means less movement, not less feedback.

Transitions are now narrowed to non-spatial properties at 120ms; anything that moves or grows snaps to its end state. Three loops are kept because each is the only continuous signal for a live state: the reconnecting logo (scale dropped, fade kept), the live dot, and the loading skeleton.

## Performance — measured, nothing shipped

On a throttled profile (4× CPU, ~1.6 Mbps, 150 ms RTT): **LCP 2.0s, CLS 0, 61KB of JS on the wire.** Both vitals already in the good band.

All three proposed optimizations were rejected on measurement:

- **`width` → `scaleX`**: 16.8ms vs **17.5ms** median, 1–3 vs 5–14 late frames across two runs at 6× throttle. Promoting forty 3px bars to compositor layers costs more than laying them out in a contained card. The measurement now lives in a comment beside the rule.
- **`content-visibility`**: layout −5…−26ms but style recalc +5…+12ms, LCP flat, and scroll height changed between runs.
- **Font preload**: FCP **1333ms** with the tag vs 1245ms without. An earlier measurement suggested a win; it was an artifact of the harness used to inject the tag, not the real build.

## Tests

**218 pass, 0 fail** (was 207). Eleven new:

- `theme-contrast.test.ts` parses `app.css`, composites each card, and does the WCAG maths over 176 token/theme pairs. Verified it bites by restoring an old value.
- e2e: one `h1` plus a stream live region; a focus ring on **every** enabled control (enumerates all 39); progressbar semantics on a mocked download; an alert region on an unreachable service; the column ladder with no horizontal overflow at four widths; a 24px tap-target sweep at 390px; reduced motion removing movement while keeping feedback.

Suite run five times to confirm the timing-sensitive e2e cases are stable.

## Also included

`PRODUCT.md` — users, purpose, positioning, constraints, and the WCAG 2.2 AA commitment that scoped this work, plus an explicit list of what does **not** exist so later work doesn't invent it.

## Found, not fixed

- **`src/web/public/sw.js` is TypeScript served as JavaScript.** It fails to parse (`Unexpected token ':'` at line 17), so the service worker has never registered and PWA offline caching has never worked since it was added. Pre-existing, three annotations to remove — but making a dead service worker start caching is a real behavioural change that deserves its own PR and a think about cache busting.
- **Pre-existing `svelte-check` errors (40)** — confirmed identical on `main` by stashing. Untouched.
