### PR TITLE
fix(pwa): make service worker valid JS with per-build cache bust

### DIFF
--- a/src/web/public/sw.js
+++ b/src/web/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'labby-cache-v1';
+const CACHE_NAME = 'labby-cache-__BUILD__';
 
 const PRECACHE_ASSETS = [
   '/',
@@ -11,52 +11,77 @@ const PRECACHE_ASSETS = [
   '/icons/labby-icon-192.png',
   '/icons/labby-icon-512.png',
   '/icons/labby-maskable-192.png',
-  '/icons/labby-maskable-512.png'
+  '/icons/labby-maskable-512.png',
 ];
 
-self.addEventListener('install', (event: any) => {
+self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(PRECACHE_ASSETS);
-    }).then(() => (self as any).skipWaiting())
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_ASSETS))
+      .then(() => self.skipWaiting()),
   );
 });
 
-self.addEventListener('activate', (event: any) => {
+self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    }).then(() => (self as any).clients.claim())
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames.map((cacheName) => {
+            if (cacheName !== CACHE_NAME) return caches.delete(cacheName);
+          }),
+        ),
+      )
+      .then(() => self.clients.claim()),
   );
 });
 
-self.addEventListener('fetch', (event: any) => {
+self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Bypass cache for API calls, settings, and non-GET requests
+  // Bypass cache for API calls and non-GET requests
   if (url.pathname.startsWith('/api/') || event.request.method !== 'GET') {
     return;
   }
 
+  // Network-first for the HTML shell so a deploy cannot pin users to a stale index.html
+  // against new hashed /assets/* bundles.
+  if (
+    event.request.mode === 'navigate' ||
+    url.pathname === '/' ||
+    url.pathname === '/index.html'
+  ) {
+    event.respondWith(
+      fetch(event.request)
+        .then((networkResponse) => {
+          if (networkResponse.status === 200) {
+            const clone = networkResponse.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
+          return networkResponse;
+        })
+        .catch(() =>
+          caches.match(event.request).then((cached) => cached || caches.match('/')),
+        ),
+    );
+    return;
+  }
+
+  // Stale-while-revalidate for static assets (icons, hashed bundles once fetched)
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
       if (cachedResponse) {
-        // Fetch in background to update cache (Stale-While-Revalidate)
-        fetch(event.request).then((networkResponse) => {
-          if (networkResponse.status === 200) {
-            caches.open(CACHE_NAME).then((cache) => {
-              cache.put(event.request, networkResponse);
-            });
-          }
-        }).catch(() => {
-          // Ignore network failure
-        });
+        fetch(event.request)
+          .then((networkResponse) => {
+            if (networkResponse.status === 200) {
+              caches.open(CACHE_NAME).then((cache) => {
+                cache.put(event.request, networkResponse);
+              });
+            }
+          })
+          .catch(() => {});
         return cachedResponse;
       }
 
@@ -68,11 +93,7 @@ self.addEventListener('fetch', (event: any) => {
           });
         }
         return networkResponse;
-      }).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/');
-        }
       });
-    })
+    }),
   );
 });

--- a/src/web/public/sw.test.ts
+++ b/src/web/public/sw.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const swPath = join(dirname(fileURLToPath(import.meta.url)), 'sw.js');
+const sw = readFileSync(swPath, 'utf8');
+
+describe('sw.js', () => {
+  test('is valid JavaScript (no TypeScript annotations)', () => {
+    // Browser and node --check both reject `: any` / `as any` in a .js file.
+    expect(sw).not.toMatch(/:\s*any\b/);
+    expect(sw).not.toMatch(/\bas any\b/);
+    // Parse as a script body — throws SyntaxError if invalid.
+    new Function(sw);
+  });
+
+  test('CACHE_NAME is stamped per build via __BUILD__ placeholder', () => {
+    expect(sw).toMatch(/CACHE_NAME\s*=\s*['"]labby-cache-__BUILD__['"]/);
+  });
+
+  test('navigations / HTML shell are network-first', () => {
+    // Deploy safety: must not serve a stale index.html before trying the network.
+    expect(sw).toMatch(/mode\s*===\s*['"]navigate['"]/);
+    const navigateIdx = sw.search(/mode\s*===\s*['"]navigate['"]/);
+    const navigateBlock = sw.slice(navigateIdx, navigateIdx + 600);
+    const fetchIdx = navigateBlock.indexOf('fetch(');
+    const cachesMatchIdx = navigateBlock.indexOf('caches.match');
+    expect(fetchIdx).toBeGreaterThanOrEqual(0);
+    expect(cachesMatchIdx).toBeGreaterThan(fetchIdx);
+  });
+});

--- a/src/web/src/main.ts
+++ b/src/web/src/main.ts
@@ -4,7 +4,8 @@ import './app.css';
 
 mount(Root, { target: document.getElementById('app')! });
 
-if ('serviceWorker' in navigator) {
+// Only register in production builds — a SW in Vite dev caches HMR shells and fights reloads.
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('/sw.js')

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,9 +1,25 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+/** Replace __BUILD__ in dist/sw.js so each deploy gets a fresh CACHE_NAME. */
+function stampServiceWorkerCache(): Plugin {
+  return {
+    name: 'stamp-sw-cache',
+    apply: 'build',
+    closeBundle() {
+      const swPath = path.resolve('dist/sw.js');
+      if (!fs.existsSync(swPath)) return;
+      const buildId = Date.now().toString(36);
+      const src = fs.readFileSync(swPath, 'utf8');
+      fs.writeFileSync(swPath, src.replaceAll('__BUILD__', buildId));
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), stampServiceWorkerCache()],
   resolve: {
     alias: {
       $lib: path.resolve('./src/lib'),


### PR DESCRIPTION
## Summary
- Fix `sw.js` TypeScript annotations that caused ServiceWorker script evaluation to fail on every load (offline caching never worked).
- Stamp `CACHE_NAME` with a per-build id via a Vite `closeBundle` plugin so each deploy busts the cache.
- Serve navigations / HTML shell network-first (fallback to cache offline) so users are not pinned to a stale `index.html` against new hashed assets; register the SW only in production.

## Test plan
- [x] `bun test src/web/public/sw.test.ts` (3 pass)
- [x] `node --check` on source and stamped `dist/sw.js`
- [x] `vite build` replaces `__BUILD__` (no leftover placeholder)
- [ ] Load production build, confirm SW registers in Application → Service Workers
- [ ] Soft-reload after a rebuild, confirm new `CACHE_NAME` and fresh shell (no stale index + broken `/assets/*`)
- [ ] Offline: shell + precached icons still load from cache