### PR TITLE
chore: pin Bun to 1.4 in Docker and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4
 
       # --frozen-lockfile: test/build the exact committed dependency graph. A PR
       # that changes a manifest without its bun.lock fails here instead of
@@ -45,5 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4
       - run: bun install --frozen-lockfile
       - run: bun run lint

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4
       - run: bun install --frozen-lockfile
       - name: Build docs
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- deps: lockfile-driven install, cached unless deps change ---
-FROM oven/bun:1 AS deps
+FROM oven/bun:1.4 AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
 COPY src/web/package.json src/web/bun.lock* ./src/web/
@@ -19,7 +19,7 @@ RUN cd src/web && bun run build
 RUN bun build src/server/index.ts --outdir dist --target bun
 
 # --- runtime: minimal, non-root, single port ---
-FROM oven/bun:1-slim AS runtime
+FROM oven/bun:1.4-slim AS runtime
 WORKDIR /app
 RUN groupadd --system labby && useradd --system --gid labby labby
 COPY --from=build /app/dist ./dist

--- a/src/web/sw.test.ts
+++ b/src/web/sw.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const swPath = join(dirname(fileURLToPath(import.meta.url)), 'sw.js');
+const swPath = join(dirname(fileURLToPath(import.meta.url)), 'public', 'sw.js');
 const sw = readFileSync(swPath, 'utf8');
 
 describe('sw.js', () => {


### PR DESCRIPTION
## Why

`Dockerfile` used `oven/bun:1` / `oven/bun:1-slim` and every `setup-bun@v2` step ran without a version, so all builds floated to the latest Bun 1.x. A Bun minor release could change the image or CI behaviour with no commit to point at.

## What

- `Dockerfile`: `oven/bun:1.4`, `oven/bun:1.4-slim`
- `bun-version: 1.4` on all four `setup-bun@v2` steps (`ci.yml` ×2, `docker.yml`, `docs.yml`)
- Move `sw.test.ts` out of `src/web/public/` — Vite copies `public/` verbatim into `dist/`, so the test file shipped to production *and* ran a second time against the built `sw.js`, where `__BUILD__` is already stamped and the placeholder assertion fails

## Bun 1.4 compatibility

Checked the [1.4 release notes](https://bun.com/blog/bun-v1.4). Three behaviour changes, none of which apply here:

| Change | Applies? |
|---|---|
| `Bun.serve` no longer serves sourcemaps for HTML routes in production | No — the SPA is a Vite build served through the Hono static handler, no HTML routes |
| `trustedDependencies` only auto-trusts the npm registry | No — no `trustedDependencies`, no `file:`/`link:`/`git:`/`github:` deps |
| macOS binaries ~1 MB larger | No — Linux/Docker only |

## Verification

Run locally on Bun 1.4.0:

- `bun install --frozen-lockfile` in both roots — no lockfile changes
- `bun run typecheck` — clean
- `bun test` — 221 pass, 0 fail
- `bun run lint` (biome) — clean
- `bun run build` — full vendor-icons → web → server bundle
- `bun run start` — bundled server boots, `/` and `/api/integrations` both 200
- `dist/` no longer contains `sw.test.ts`