### PR TITLE
chore: adopt Bun 1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun test
+        run: bun run test
 
       # build:web (Vite) + build:server (bun bundle) compile the SPA and server.
       # Skips the `vendor-icons` step so CI needs no CDN network (icons are a

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM oven/bun:1.4 AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
 COPY src/web/package.json src/web/bun.lock* ./src/web/
-RUN bun install && cd src/web && bun install
+RUN bun install --frozen-lockfile && cd src/web && bun install --frozen-lockfile
 
 # --- build: compile the Svelte SPA + bundle the server into one process ---
 FROM deps AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # --- deps: lockfile-driven install, cached unless deps change ---
 FROM oven/bun:1.4 AS deps
 WORKDIR /app
-COPY package.json bun.lock* ./
+COPY package.json bun.lock* bunfig.toml ./
 COPY src/web/package.json src/web/bun.lock* ./src/web/
 RUN bun install --frozen-lockfile && cd src/web && bun install --frozen-lockfile
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
-        "@types/bun": "latest",
+        "@types/bun": "^1.4.0",
         "playwright": "1.61.0",
         "svelte": "^5.20.5",
         "typescript": "^7.0.2",
@@ -227,7 +227,7 @@
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
@@ -335,7 +335,7 @@
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -383,7 +383,7 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
@@ -419,7 +419,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
@@ -433,7 +433,7 @@
 
     "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "preact": ["preact@10.29.6", "", {}, "sha512-/UzLXnc1jrAS2uHi89XsSECqXVHYzV1VUL1L3esxrmPRmDvKFWtmbabE2a4QQ5a3bLgBivubRCEOt4GGmncPBQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,5 @@
+[install]
+linker = "isolated"
+
 [test]
 preload = ["./test/setup.ts"]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:web": "cd src/web && bun run build",
     "build:server": "bun build src/server/index.ts --outdir dist --target bun",
     "start": "bun run dist/index.js",
-    "test": "bun test",
+    "test": "bun test --parallel",
     "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome check --write",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "@types/bun": "latest",
+    "@types/bun": "^1.4.0",
     "playwright": "1.61.0",
     "svelte": "^5.20.5",
     "typescript": "^7.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["bun-types"],
+    "types": ["bun"],
     "paths": {
       "@server/*": ["./src/server/*"]
     }


### PR DESCRIPTION
## What

| Change | Detail |
|---|---|
| Install | `bunfig.toml`: `linker = "isolated"` (Bun 1.4 virtual store) — warm install 170ms → 22ms |
| Types | tsconfig `"types": ["bun-types"]` → `["bun"]`; `@types/bun` pinned `^1.4.0` (was `latest`) |
| Tests | `bun test --parallel` for the 221-test suite |
| Security | `bun audit fix` — **15 → 4 advisories** |
| Docker | deps stage installs with `--frozen-lockfile` |

## The tsconfig fix

The isolated linker exposed a latent bug: `"types": ["bun-types"]` named a package this repo never declared as a dependency. It resolved only because the hoisted layout happened to expose a transitive copy. Under the virtual store it fails outright — `error TS2688: Cannot find type definition file for 'bun-types'`. Switched to `["bun"]`, which matches the `@types/bun` devDependency that is actually declared.

`Dockerfile` stays on the floating `oven/bun:1.4` tag.

## Verification

221 tests pass, `tsc --noEmit` clean, `bun run build` clean, `docker build` succeeds.